### PR TITLE
WIP json for HTML report.

### DIFF
--- a/composer/build.gradle
+++ b/composer/build.gradle
@@ -15,6 +15,7 @@ dependencies {
     compile libraries.commanderAndroid
     compile libraries.apacheCommonsIo
     compile libraries.apacheCommonsLang
+    compile libraries.gson
 }
 
 dependencies {

--- a/composer/src/main/kotlin/com/gojuno/composer/Files.kt
+++ b/composer/src/main/kotlin/com/gojuno/composer/Files.kt
@@ -10,6 +10,8 @@ import java.lang.Exception
 
 fun tail(file: File): Observable<String> = Observable.create<String>(
         { emitter ->
+            val o = None
+          
             Tailer.create(file, object : TailerListener {
                 override fun init(tailer: Tailer) = emitter.setCancellation { tailer.stop() }
                 override fun handle(line: String) = emitter.onNext(line)
@@ -20,3 +22,8 @@ fun tail(file: File): Observable<String> = Observable.create<String>(
         },
         BackpressureMode.BUFFER
 )
+
+sealed class Optional<out T : Any>
+
+data class Some<out T : Any>(val value: T) : Optional<T>()
+object None : Optional<Nothing>()

--- a/composer/src/main/kotlin/com/gojuno/composer/Instrumentation.kt
+++ b/composer/src/main/kotlin/com/gojuno/composer/Instrumentation.kt
@@ -1,20 +1,20 @@
 package com.gojuno.composer
 
-import com.gojuno.composer.Test.Result.*
+import com.gojuno.composer.InstrumentationTest.Status.*
 import rx.Observable
 import java.io.File
 
-data class Test(
+data class InstrumentationTest(
         val className: String,
         val testName: String,
-        val result: Result,
+        val status: Status,
         val durationNanos: Long
 ) {
 
-    sealed class Result {
-        object Passed : Result()
-        object Ignored : Result()
-        data class Failed(val stacktrace: String) : Result()
+    sealed class Status {
+        object Passed : Status()
+        object Ignored : Status()
+        data class Failed(val stacktrace: String) : Status()
     }
 }
 
@@ -74,7 +74,7 @@ private fun parseInstrumentationEntry(str: String): InstrumentationEntry =
                         }
                         .let { statusCode ->
                             when (statusCode) {
-                                null -> throw IllegalStateException("Unknown test result status code [$statusCode], please report that to Composer maintainers $str")
+                                null -> throw IllegalStateException("Unknown test status status code [$statusCode], please report that to Composer maintainers $str")
                                 else -> statusCode
                             }
                         },
@@ -101,13 +101,13 @@ fun readInstrumentationOutput(output: File): Observable<InstrumentationEntry> {
             .map { parseInstrumentationEntry(it.buffer) }
 }
 
-fun Observable<InstrumentationEntry>.asTests(): Observable<Test> {
-    data class result(val entries: List<InstrumentationEntry> = emptyList(), val tests: List<Test> = emptyList(), val totalTestsCount: Int = 0)
+fun Observable<InstrumentationEntry>.asTests(): Observable<InstrumentationTest> {
+    data class result(val entries: List<InstrumentationEntry> = emptyList(), val tests: List<InstrumentationTest> = emptyList(), val totalTestsCount: Int = 0)
 
     return this
             .scan(result()) { previousResult, newEntry ->
                 val entries = previousResult.entries + newEntry
-                val tests: List<Test> = entries
+                val tests: List<InstrumentationTest> = entries
                         .mapIndexed { index, first ->
                             val second = entries
                                     .subList(index + 1, entries.size)
@@ -125,10 +125,10 @@ fun Observable<InstrumentationEntry>.asTests(): Observable<Test> {
                         }
                         .filterNotNull()
                         .map { (first, second) ->
-                            Test(
+                            InstrumentationTest(
                                     className = first.clazz,
                                     testName = first.test,
-                                    result = when (second.statusCode) {
+                                    status = when (second.statusCode) {
                                         StatusCode.Ok -> Passed
                                         StatusCode.Ignored -> Ignored
                                         StatusCode.Failure, StatusCode.AssumptionFailure -> Failed(stacktrace = second.stack)

--- a/composer/src/main/kotlin/com/gojuno/composer/Instrumentation.kt
+++ b/composer/src/main/kotlin/com/gojuno/composer/Instrumentation.kt
@@ -74,7 +74,7 @@ private fun parseInstrumentationEntry(str: String): InstrumentationEntry =
                         }
                         .let { statusCode ->
                             when (statusCode) {
-                                null -> throw IllegalStateException("Unknown test status status code [$statusCode], please report that to Composer maintainers $str")
+                                null -> throw IllegalStateException("Unknown test status code [$statusCode], please report that to Composer maintainers $str")
                                 else -> statusCode
                             }
                         },

--- a/composer/src/main/kotlin/com/gojuno/composer/Main.kt
+++ b/composer/src/main/kotlin/com/gojuno/composer/Main.kt
@@ -13,9 +13,9 @@ import java.io.File
 
 sealed class Exit(val code: Int, val message: String?) {
     object Ok : Exit(code = 0, message = null)
-    object NoDevicesAvailableForTests : Exit(code = 1, message = "No devices available for tests.")
-    object ThereWereFailedTests : Exit(code = 1, message = "There were failed tests.")
-    object NoTests : Exit(code = 1, message = "0 tests were run.")
+    object NoDevicesAvailableForTests : Exit(code = 1, message = "Error: No devices available for tests.")
+    object ThereWereFailedTests : Exit(code = 1, message = "Error: There were failed tests.")
+    object NoTests : Exit(code = 1, message = "Error: 0 tests were run.")
 }
 
 fun exit(exit: Exit) {

--- a/composer/src/main/kotlin/com/gojuno/composer/Main.kt
+++ b/composer/src/main/kotlin/com/gojuno/composer/Main.kt
@@ -4,7 +4,9 @@ import com.gojuno.commander.android.connectedAdbDevices
 import com.gojuno.commander.android.installApk
 import com.gojuno.commander.os.log
 import com.gojuno.commander.os.nanosToHumanReadableTime
+import com.gojuno.composer.html.writeHtmlReport
 import com.gojuno.janulator.parseArgs
+import com.google.gson.Gson
 import rx.Observable
 import rx.schedulers.Schedulers
 import java.io.File
@@ -24,15 +26,17 @@ fun exit(exit: Exit) {
 }
 
 fun main(rawArgs: Array<String>) {
+    val startTime = System.nanoTime()
+
     val args = parseArgs(rawArgs)
 
     if (args.verboseOutput) {
         log("$args")
     }
 
-    val startTime = System.nanoTime()
+    val gson = Gson()
 
-    val testRunResults: List<TestRunResult> = connectedAdbDevices()
+    val suites: List<Suite> = connectedAdbDevices()
             .map {
                 it.filter { it.online }.apply {
                     if (isEmpty()) {
@@ -42,7 +46,7 @@ fun main(rawArgs: Array<String>) {
             }
             .doOnNext { log("${it.size} connected adb device(s): $it") }
             .flatMap { connectedAdbDevices ->
-                val runTestsOnDevices: List<Observable<TestRunResult>> = connectedAdbDevices.mapIndexed { index, device ->
+                val runTestsOnDevices: List<Observable<AdbDeviceTestRun>> = connectedAdbDevices.mapIndexed { index, device ->
                     val installAppApk = device.installApk(pathToApk = args.appApkPath)
                     val installTestApk = device.installApk(pathToApk = args.testApkPath)
 
@@ -70,27 +74,56 @@ fun main(rawArgs: Array<String>) {
                                                 outputDir = File(args.outputDirectory),
                                                 verboseOutput = args.verboseOutput
                                         )
-                                        .flatMap { testRunResult ->
+                                        .flatMap { adbDeviceTestRun ->
                                             writeJunit4Report(
-                                                    testRunResult = testRunResult,
+                                                    suite = adbDeviceTestRun.toSuite(args.testPackage),
                                                     outputFile = File(File(args.outputDirectory, "junit4-reports"), "${device.id}.xml")
-                                            ).toSingleDefault(testRunResult)
+                                            ).toSingleDefault(adbDeviceTestRun)
                                         }
                                         .subscribeOn(Schedulers.io())
                                         .toObservable()
                             }
                 }
+                Observable.zip(runTestsOnDevices, { results -> results.map { it as AdbDeviceTestRun } })
+            }
+            .map { adbDeviceTestRuns ->
+                when (args.shard) {
+                // In "shard=true" mode test runs from all devices combined into one suite of tests.
+                    true -> listOf(Suite(
+                            testPackage = args.testPackage,
+                            devices = adbDeviceTestRuns.fold(emptyList()) { devices, adbDeviceTestRun ->
+                                devices + Device(
+                                        id = adbDeviceTestRun.adbDevice.id,
+                                        logcat = adbDeviceTestRun.logcat,
+                                        instrumentationOutput = adbDeviceTestRun.instrumentationOutput
+                                )
+                            },
+                            tests = adbDeviceTestRuns.map { it.tests }.fold(emptyList()) { result, tests ->
+                                result + tests
+                            },
+                            passedCount = adbDeviceTestRuns.sumBy { it.passedCount },
+                            ignoredCount = adbDeviceTestRuns.sumBy { it.ignoredCount },
+                            failedCount = adbDeviceTestRuns.sumBy { it.failedCount },
+                            durationNanos = adbDeviceTestRuns.map { it.durationNanos }.max() ?: -1,
+                            timestampMillis = adbDeviceTestRuns.map { it.timestampMillis }.min() ?: -1
+                    ))
 
-                Observable.zip(runTestsOnDevices, { results -> results.map { it as TestRunResult } })
+                // In "shard=false" mode test run from each device represented as own suite of tests.  
+                    false -> adbDeviceTestRuns.map { it.toSuite(args.testPackage) }
+                }
+            }
+            .flatMap { suites ->
+                writeHtmlReport(gson, suites, File(args.outputDirectory, "html-report"))
+                        .andThen(Observable.just(suites))
             }
             .toBlocking()
             .first()
 
     val duration = (System.nanoTime() - startTime)
 
-    val totalPassed = testRunResults.sumBy { it.passedCount }
-    val totalFailed = testRunResults.sumBy { it.failedCount }
-    val totalIgnored = testRunResults.sumBy { it.ignoredCount }
+    val totalPassed = suites.sumBy { it.passedCount }
+    val totalFailed = suites.sumBy { it.failedCount }
+    val totalIgnored = suites.sumBy { it.ignoredCount }
 
     log("Test run finished, total passed = $totalPassed, total failed = $totalFailed, total ignored = $totalIgnored, took ${duration.nanosToHumanReadableTime()}.")
 
@@ -101,3 +134,34 @@ fun main(rawArgs: Array<String>) {
     }
 }
 
+data class Suite(
+        val testPackage: String,
+        val devices: List<Device>,
+        val tests: List<AdbDeviceTest>, // TODO: switch to separate Test class.
+        val passedCount: Int,
+        val ignoredCount: Int,
+        val failedCount: Int,
+        val durationNanos: Long,
+        val timestampMillis: Long
+)
+
+data class Device(
+        val id: String,
+        val logcat: File,
+        val instrumentationOutput: File
+)
+
+fun AdbDeviceTestRun.toSuite(testPackage: String): Suite = Suite(
+        testPackage = testPackage,
+        devices = listOf(Device(
+                id = adbDevice.id,
+                logcat = logcat,
+                instrumentationOutput = instrumentationOutput
+        )),
+        tests = tests,
+        passedCount = passedCount,
+        ignoredCount = ignoredCount,
+        failedCount = failedCount,
+        durationNanos = durationNanos,
+        timestampMillis = timestampMillis
+)

--- a/composer/src/main/kotlin/com/gojuno/composer/TestRun.kt
+++ b/composer/src/main/kotlin/com/gojuno/composer/TestRun.kt
@@ -160,12 +160,17 @@ private fun pullTestFiles(adbDevice: AdbDevice, test: InstrumentationTest, outpu
                             folderOnHostMachine = screenshotsFolderOnHostMachine,
                             logErrors = verboseOutput
                     )
-                    .map { screenshotsFolderOnHostMachine }
+                    .map { File(screenshotsFolderOnHostMachine, test.testName) }
         }
         .map { screenshotsFolderOnHostMachine ->
             PulledFiles(
                     files = emptyList(), // TODO: Pull test files.
-                    screenshots = screenshotsFolderOnHostMachine.listFiles().toList()
+                    screenshots = screenshotsFolderOnHostMachine.let {
+                        when (it.exists()) {
+                            true -> it.listFiles().toList()
+                            else -> emptyList()
+                        }
+                    }
             )
         }
 

--- a/composer/src/main/kotlin/com/gojuno/composer/html/HtmlDevice.kt
+++ b/composer/src/main/kotlin/com/gojuno/composer/html/HtmlDevice.kt
@@ -1,0 +1,22 @@
+package com.gojuno.composer.html
+
+import com.gojuno.composer.Device
+import com.google.gson.annotations.SerializedName
+
+data class HtmlDevice(
+
+        @SerializedName("id")
+        val id: String,
+
+        @SerializedName("logcatPath")
+        val logcatPath: String,
+
+        @SerializedName("instrumentationOutputPath")
+        val instrumentationOutputPath: String
+)
+
+fun Device.toHtmlDevice() = HtmlDevice(
+        id = id,
+        logcatPath = logcat.path,
+        instrumentationOutputPath = instrumentationOutput.path
+)

--- a/composer/src/main/kotlin/com/gojuno/composer/html/HtmlDevice.kt
+++ b/composer/src/main/kotlin/com/gojuno/composer/html/HtmlDevice.kt
@@ -8,10 +8,10 @@ data class HtmlDevice(
         @SerializedName("id")
         val id: String,
 
-        @SerializedName("logcatPath")
+        @SerializedName("logcat_path")
         val logcatPath: String,
 
-        @SerializedName("instrumentationOutputPath")
+        @SerializedName("instrumentation_output_path")
         val instrumentationOutputPath: String
 )
 

--- a/composer/src/main/kotlin/com/gojuno/composer/html/HtmlFullSuite.kt
+++ b/composer/src/main/kotlin/com/gojuno/composer/html/HtmlFullSuite.kt
@@ -1,0 +1,41 @@
+package com.gojuno.composer.html
+
+import com.gojuno.composer.Device
+import com.gojuno.composer.Suite
+import com.google.gson.annotations.SerializedName
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.TimeUnit.*
+
+data class HtmlFullSuite(
+        
+        @SerializedName("id")
+        val id: String,
+        
+        @SerializedName("tests")
+        val tests: List<HtmlTest>,
+
+        @SerializedName("passedCount")
+        val passedCount: Int,
+
+        @SerializedName("ignoredCount")
+        val ignoredCount: Int,
+
+        @SerializedName("failedCount")
+        val failedCount: Int,
+
+        @SerializedName("durationMillis")
+        val durationMillis: Long,
+
+        @SerializedName("devices")
+        val devices: List<HtmlDevice>
+)
+
+fun Suite.toHtmlFullSuite(id: String) = HtmlFullSuite(
+        id = id,
+        tests = tests.map { it.toHtmlTest() },
+        passedCount = passedCount,
+        ignoredCount = ignoredCount,
+        failedCount = failedCount,
+        durationMillis = NANOSECONDS.toMillis(durationNanos),
+        devices = devices.map(Device::toHtmlDevice)
+)

--- a/composer/src/main/kotlin/com/gojuno/composer/html/HtmlFullSuite.kt
+++ b/composer/src/main/kotlin/com/gojuno/composer/html/HtmlFullSuite.kt
@@ -3,8 +3,7 @@ package com.gojuno.composer.html
 import com.gojuno.composer.Device
 import com.gojuno.composer.Suite
 import com.google.gson.annotations.SerializedName
-import java.util.concurrent.TimeUnit
-import java.util.concurrent.TimeUnit.*
+import java.util.concurrent.TimeUnit.NANOSECONDS
 
 data class HtmlFullSuite(
         
@@ -14,16 +13,16 @@ data class HtmlFullSuite(
         @SerializedName("tests")
         val tests: List<HtmlTest>,
 
-        @SerializedName("passedCount")
+        @SerializedName("passed_count")
         val passedCount: Int,
 
-        @SerializedName("ignoredCount")
+        @SerializedName("ignored_count")
         val ignoredCount: Int,
 
-        @SerializedName("failedCount")
+        @SerializedName("failed_count")
         val failedCount: Int,
 
-        @SerializedName("durationMillis")
+        @SerializedName("duration_millis")
         val durationMillis: Long,
 
         @SerializedName("devices")

--- a/composer/src/main/kotlin/com/gojuno/composer/html/HtmlIndex.kt
+++ b/composer/src/main/kotlin/com/gojuno/composer/html/HtmlIndex.kt
@@ -1,0 +1,9 @@
+package com.gojuno.composer.html
+
+import com.google.gson.annotations.SerializedName
+
+data class HtmlIndex(
+        
+        @SerializedName("suites")
+        val suites: List<HtmlShortSuite>
+)

--- a/composer/src/main/kotlin/com/gojuno/composer/html/HtmlReport.kt
+++ b/composer/src/main/kotlin/com/gojuno/composer/html/HtmlReport.kt
@@ -1,0 +1,25 @@
+package com.gojuno.composer.html
+
+import com.gojuno.composer.Suite
+import com.google.gson.Gson
+import rx.Completable
+import java.io.File
+
+fun writeHtmlReport(gson: Gson, suites: List<Suite>, outputDir: File): Completable = Completable.fromCallable {
+    outputDir.parentFile.mkdirs()
+
+    val htmlIndexJson = gson.toJson(
+            HtmlIndex(
+                    suites = suites.mapIndexed { index, suite -> suite.toHtmlShortSuite(id = "$index") }
+            )
+    )
+
+    File(outputDir, "index.json").writeText(htmlIndexJson)
+
+    val suitesDir = File(outputDir, "suites").apply { mkdirs() }
+
+    suites.mapIndexed { index, suite ->
+        val suiteJson = gson.toJson(suite.toHtmlFullSuite(id = "$index"))
+        File(suitesDir, "$index.json").writeText(suiteJson)
+    }
+}

--- a/composer/src/main/kotlin/com/gojuno/composer/html/HtmlReport.kt
+++ b/composer/src/main/kotlin/com/gojuno/composer/html/HtmlReport.kt
@@ -6,7 +6,7 @@ import rx.Completable
 import java.io.File
 
 fun writeHtmlReport(gson: Gson, suites: List<Suite>, outputDir: File): Completable = Completable.fromCallable {
-    outputDir.parentFile.mkdirs()
+    outputDir.mkdirs()
 
     val htmlIndexJson = gson.toJson(
             HtmlIndex(

--- a/composer/src/main/kotlin/com/gojuno/composer/html/HtmlShortSuite.kt
+++ b/composer/src/main/kotlin/com/gojuno/composer/html/HtmlShortSuite.kt
@@ -1,0 +1,36 @@
+package com.gojuno.composer.html
+
+import com.gojuno.composer.Device
+import com.gojuno.composer.Suite
+import com.google.gson.annotations.SerializedName
+import java.util.concurrent.TimeUnit.NANOSECONDS
+
+data class HtmlShortSuite(
+        
+        @SerializedName("id")
+        val id: String,
+
+        @SerializedName("passedCount")
+        val passedCount: Int,
+
+        @SerializedName("ignoredCount")
+        val ignoredCount: Int,
+
+        @SerializedName("failedCount")
+        val failedCount: Int,
+
+        @SerializedName("durationMillis")
+        val durationMillis: Long,
+
+        @SerializedName("devices")
+        val devices: List<HtmlDevice>
+)
+
+fun Suite.toHtmlShortSuite(id: String) = HtmlShortSuite(
+        id = id,
+        passedCount = passedCount,
+        ignoredCount = ignoredCount,
+        failedCount = failedCount,
+        durationMillis = NANOSECONDS.toMillis(durationNanos),
+        devices = devices.map(Device::toHtmlDevice)
+)

--- a/composer/src/main/kotlin/com/gojuno/composer/html/HtmlShortSuite.kt
+++ b/composer/src/main/kotlin/com/gojuno/composer/html/HtmlShortSuite.kt
@@ -10,16 +10,16 @@ data class HtmlShortSuite(
         @SerializedName("id")
         val id: String,
 
-        @SerializedName("passedCount")
+        @SerializedName("passed_count")
         val passedCount: Int,
 
-        @SerializedName("ignoredCount")
+        @SerializedName("ignored_count")
         val ignoredCount: Int,
 
-        @SerializedName("failedCount")
+        @SerializedName("failed_count")
         val failedCount: Int,
 
-        @SerializedName("durationMillis")
+        @SerializedName("duration_millis")
         val durationMillis: Long,
 
         @SerializedName("devices")

--- a/composer/src/main/kotlin/com/gojuno/composer/html/HtmlTest.kt
+++ b/composer/src/main/kotlin/com/gojuno/composer/html/HtmlTest.kt
@@ -1,0 +1,74 @@
+package com.gojuno.composer.html
+
+import com.gojuno.composer.AdbDeviceTest
+import com.google.gson.annotations.SerializedName
+import java.util.concurrent.TimeUnit.NANOSECONDS
+
+data class HtmlTest(
+
+        @SerializedName("packageName")
+        val packageName: String,
+
+        @SerializedName("className")
+        val className: String,
+
+        @SerializedName("name")
+        val name: String,
+
+        @SerializedName("durationMillis")
+        val durationMillis: Long,
+
+        @SerializedName("status")
+        val status: Status,
+        
+        @SerializedName("stacktrace")
+        val stacktrace: String?,
+
+        @SerializedName("logcatPath")
+        val logcatPath: String,
+
+        @SerializedName("deviceId")
+        val deviceId: String,
+
+        @SerializedName("properties")
+        val properties: Map<String, Any>,
+
+        @SerializedName("filePaths")
+        val filePaths: List<String>,
+
+        @SerializedName("screenshotsPaths")
+        val screenshotsPaths: List<String>
+) {
+    enum class Status {
+
+        @SerializedName("passed")
+        Passed,
+
+        @SerializedName("failed")
+        Failed,
+
+        @SerializedName("ignored")
+        Ignored
+    }
+}
+
+fun AdbDeviceTest.toHtmlTest() = HtmlTest(
+        packageName = className.substringBeforeLast("."),
+        className = className.substringAfterLast("."),
+        name = testName,
+        durationMillis = NANOSECONDS.toMillis(durationNanos),
+        status = when (status) {
+            AdbDeviceTest.Status.Passed -> HtmlTest.Status.Passed
+            AdbDeviceTest.Status.Ignored -> HtmlTest.Status.Ignored
+            is AdbDeviceTest.Status.Failed -> HtmlTest.Status.Failed
+        },
+        stacktrace = when (status) {
+            is AdbDeviceTest.Status.Failed -> status.stacktrace
+            else -> null
+        },
+        logcatPath = logcat.path,
+        deviceId = adbDevice.id,
+        properties = emptyMap(), // TODO: add properties support.
+        filePaths = files.map { it.path },
+        screenshotsPaths = screenshots.map { it.path }
+)

--- a/composer/src/main/kotlin/com/gojuno/composer/html/HtmlTest.kt
+++ b/composer/src/main/kotlin/com/gojuno/composer/html/HtmlTest.kt
@@ -6,16 +6,16 @@ import java.util.concurrent.TimeUnit.NANOSECONDS
 
 data class HtmlTest(
 
-        @SerializedName("packageName")
+        @SerializedName("package_name")
         val packageName: String,
 
-        @SerializedName("className")
+        @SerializedName("class_name")
         val className: String,
 
         @SerializedName("name")
         val name: String,
 
-        @SerializedName("durationMillis")
+        @SerializedName("duration_millis")
         val durationMillis: Long,
 
         @SerializedName("status")
@@ -24,7 +24,7 @@ data class HtmlTest(
         @SerializedName("stacktrace")
         val stacktrace: String?,
 
-        @SerializedName("logcatPath")
+        @SerializedName("logcat_path")
         val logcatPath: String,
 
         @SerializedName("deviceId")
@@ -33,10 +33,10 @@ data class HtmlTest(
         @SerializedName("properties")
         val properties: Map<String, Any>,
 
-        @SerializedName("filePaths")
+        @SerializedName("file_paths")
         val filePaths: List<String>,
 
-        @SerializedName("screenshotsPaths")
+        @SerializedName("screenshots_paths")
         val screenshotsPaths: List<String>
 ) {
     enum class Status {

--- a/composer/src/test/kotlin/com/gojuno/composer/InstrumentationSpec.kt
+++ b/composer/src/test/kotlin/com/gojuno/composer/InstrumentationSpec.kt
@@ -1,6 +1,6 @@
 package com.gojuno.composer
 
-import com.gojuno.composer.Test.Result.*
+import com.gojuno.composer.InstrumentationTest.Status.*
 import org.assertj.core.api.Assertions.assertThat
 import org.jetbrains.spek.api.Spek
 import org.jetbrains.spek.api.dsl.context
@@ -199,7 +199,7 @@ at android.app.Instrumentation.InstrumentationThread.run(Instrumentation.java:19
 
         context("as tests") {
 
-            val testsSubscriber by memoized { TestSubscriber<Test>() }
+            val testsSubscriber by memoized { TestSubscriber<InstrumentationTest>() }
 
             perform {
                 entries.asTests().subscribe(testsSubscriber)
@@ -209,10 +209,10 @@ at android.app.Instrumentation.InstrumentationThread.run(Instrumentation.java:19
             it("emits expected tests") {
                 // We have no control over system time in tests.
                 assertThat(testsSubscriber.onNextEvents.map { it.copy(durationNanos = 0) }).isEqualTo(listOf(
-                        Test(
+                        InstrumentationTest(
                                 className = "com.example.test.TestClass",
                                 testName = "test1",
-                                result = Failed(stacktrace = """java.net.UnknownHostException: Test Exception
+                                status = Failed(stacktrace = """java.net.UnknownHostException: Test Exception
 at com.example.test.TestClass.test1.1.invoke(TestClass.kt:245)
 at com.example.test.TestClass.test1.1.invoke(TestClass.kt:44)
 at com.example.test.TestClass.test1(TestClass.kt:238)
@@ -252,22 +252,22 @@ at android.support.test.runner.JunoAndroidRunner.onStart(JunoAndroidRunner.kt:10
 at android.app.Instrumentation.InstrumentationThread.run(Instrumentation.java:1932)"""),
                                 durationNanos = 0
                         ),
-                        Test(
+                        InstrumentationTest(
                                 className = "com.example.test.TestClass",
                                 testName = "test2",
-                                result = Passed,
+                                status = Passed,
                                 durationNanos = 0
                         ),
-                        Test(
+                        InstrumentationTest(
                                 className = "com.example.test.TestClass",
                                 testName = "test3",
-                                result = Passed,
+                                status = Passed,
                                 durationNanos = 0
                         ),
-                        Test(
+                        InstrumentationTest(
                                 className = "com.example.test.TestClass",
                                 testName = "test4",
-                                result = Passed,
+                                status = Passed,
                                 durationNanos = 0
                         )
                 ))
@@ -307,7 +307,7 @@ at android.app.Instrumentation.InstrumentationThread.run(Instrumentation.java:19
 
         context("as tests") {
 
-            val testsSubscriber by memoized { TestSubscriber<Test>() }
+            val testsSubscriber by memoized { TestSubscriber<InstrumentationTest>() }
 
             perform {
                 entries.asTests().subscribe(testsSubscriber)
@@ -420,7 +420,7 @@ at android.app.Instrumentation.InstrumentationThread.run(Instrumentation.java:19
 
         context("as tests") {
 
-            val testsSubscriber by memoized { TestSubscriber<Test>() }
+            val testsSubscriber by memoized { TestSubscriber<InstrumentationTest>() }
 
             perform {
                 entries.asTests().subscribe(testsSubscriber)
@@ -429,22 +429,22 @@ at android.app.Instrumentation.InstrumentationThread.run(Instrumentation.java:19
 
             it("emits expected tests") {
                 assertThat(testsSubscriber.onNextEvents.map { it.copy(durationNanos = 0) }).isEqualTo(listOf(
-                        Test(
+                        InstrumentationTest(
                                 className = "com.example.test.TestClass",
                                 testName = "test1",
-                                result = Passed,
+                                status = Passed,
                                 durationNanos = 0L
                         ),
-                        Test(
+                        InstrumentationTest(
                                 className = "com.example.test.TestClass",
                                 testName = "test2",
-                                result = Passed,
+                                status = Passed,
                                 durationNanos = 0L
                         ),
-                        Test(
+                        InstrumentationTest(
                                 className = "com.example.test.TestClass",
                                 testName = "test3",
-                                result = Passed,
+                                status = Passed,
                                 durationNanos = 0L
                         )
                 ))
@@ -530,7 +530,7 @@ at android.app.Instrumentation.InstrumentationThread.run(Instrumentation.java:19
 
         context("as tests") {
 
-            val testsSubscriber by memoized { TestSubscriber<Test>() }
+            val testsSubscriber by memoized { TestSubscriber<InstrumentationTest>() }
 
             perform {
                 entries.asTests().subscribe(testsSubscriber)
@@ -539,16 +539,16 @@ at android.app.Instrumentation.InstrumentationThread.run(Instrumentation.java:19
 
             it("emits expected tests") {
                 assertThat(testsSubscriber.onNextEvents.map { it.copy(durationNanos = 0) }).isEqualTo(listOf(
-                        Test(
+                        InstrumentationTest(
                                 className = "com.example.test.TestClass",
                                 testName = "test1",
-                                result = Passed,
+                                status = Passed,
                                 durationNanos = 0L
                         ),
-                        Test(
+                        InstrumentationTest(
                                 className = "com.example.test.TestClass",
                                 testName = "test2",
-                                result = Ignored,
+                                status = Ignored,
                                 durationNanos = 0L
                         )
                 ))

--- a/composer/src/test/kotlin/com/gojuno/composer/JUnitReportSpec.kt
+++ b/composer/src/test/kotlin/com/gojuno/composer/JUnitReportSpec.kt
@@ -1,6 +1,7 @@
 package com.gojuno.composer
 
-import com.gojuno.composer.Test.Result.*
+import com.gojuno.commander.android.AdbDevice
+import com.gojuno.composer.AdbDeviceTest.Status.*
 import org.assertj.core.api.Assertions.assertThat
 import org.jetbrains.spek.api.Spek
 import org.jetbrains.spek.api.dsl.context
@@ -11,39 +12,57 @@ import java.util.concurrent.TimeUnit.SECONDS
 
 class JUnitReportSpec : Spek({
 
-    context("write test run result to junit4 report to file") {
+    context("write test run result as junit4 report to file") {
 
+        val adbDevice by memoized { AdbDevice(id = "testDevice", online = true) }
         val subscriber by memoized { TestSubscriber<Unit>() }
         val outputFile by memoized { testFile() }
 
         perform {
             writeJunit4Report(
-                    testRunResult = TestRunResult(
-                            testPackageName = "com.gojuno.test",
+                    suite = Suite(
+                            testPackage = "com.gojuno.test",
+                            devices = listOf(Device(id = adbDevice.id, logcat = testFile(), instrumentationOutput = testFile())),
                             tests = listOf(
-                                    Test(
+                                    AdbDeviceTest(
+                                            adbDevice = adbDevice,
                                             className = "test.class.name1",
                                             testName = "test1",
-                                            result = Passed,
-                                            durationNanos = SECONDS.toNanos(2)
+                                            status = Passed,
+                                            durationNanos = SECONDS.toNanos(2),
+                                            logcat = testFile(),
+                                            files = emptyList(),
+                                            screenshots = emptyList()
                                     ),
-                                    Test(
+                                    AdbDeviceTest(
+                                            adbDevice = adbDevice,
                                             className = "test.class.name2",
                                             testName = "test2",
-                                            result = Failed(stacktrace = "multi\nline\nstacktrace"),
-                                            durationNanos = MILLISECONDS.toNanos(3250)
+                                            status = Failed(stacktrace = "multi\nline\nstacktrace"),
+                                            durationNanos = MILLISECONDS.toNanos(3250),
+                                            logcat = testFile(),
+                                            files = emptyList(),
+                                            screenshots = emptyList()
                                     ),
-                                    Test(
+                                    AdbDeviceTest(
+                                            adbDevice = adbDevice,
                                             className = "test.class.name3",
                                             testName = "test3",
-                                            result = Passed,
-                                            durationNanos = SECONDS.toNanos(1)
+                                            status = Passed,
+                                            durationNanos = SECONDS.toNanos(1),
+                                            logcat = testFile(),
+                                            files = emptyList(),
+                                            screenshots = emptyList()
                                     ),
-                                    Test(
+                                    AdbDeviceTest(
+                                            adbDevice = adbDevice,
                                             className = "test.class.name4",
                                             testName = "test4",
-                                            result = Ignored,
-                                            durationNanos = SECONDS.toNanos(0)
+                                            status = Ignored,
+                                            durationNanos = SECONDS.toNanos(0),
+                                            logcat = testFile(),
+                                            files = emptyList(),
+                                            screenshots = emptyList()
                                     )
                             ),
                             passedCount = 2,

--- a/composer/src/test/kotlin/com/gojuno/composer/html/HtmlDeviceSpec.kt
+++ b/composer/src/test/kotlin/com/gojuno/composer/html/HtmlDeviceSpec.kt
@@ -1,0 +1,26 @@
+package com.gojuno.composer.html
+
+import com.gojuno.composer.Device
+import com.gojuno.composer.testFile
+import org.assertj.core.api.Assertions.assertThat
+import org.jetbrains.spek.api.Spek
+import org.jetbrains.spek.api.dsl.context
+import org.jetbrains.spek.api.dsl.it
+
+class HtmlDeviceSpec : Spek({
+
+    context("Device.toHtmlDevice") {
+
+        val device = Device(id = "testDevice1", logcat = testFile(), instrumentationOutput = testFile())
+
+        val htmlDevice = device.toHtmlDevice()
+
+        it("converts Device to HtmlDevice") {
+            assertThat(htmlDevice).isEqualTo(HtmlDevice(
+                    id = device.id,
+                    logcatPath = device.logcat.path,
+                    instrumentationOutputPath = device.instrumentationOutput.path
+            ))
+        }
+    }
+})

--- a/composer/src/test/kotlin/com/gojuno/composer/html/HtmlFullSuiteSpec.kt
+++ b/composer/src/test/kotlin/com/gojuno/composer/html/HtmlFullSuiteSpec.kt
@@ -11,9 +11,9 @@ import org.jetbrains.spek.api.dsl.context
 import org.jetbrains.spek.api.dsl.it
 import java.util.concurrent.TimeUnit.NANOSECONDS
 
-class HtmlShortSuiteSpec : Spek({
+class HtmlFullSuiteSpec : Spek({
 
-    context("Suite.toHtmlShortSuite") {
+    context("Suite.toHtmlFullSuite") {
         val suite = Suite(
                 testPackage = "p",
                 devices = listOf(
@@ -49,16 +49,17 @@ class HtmlShortSuiteSpec : Spek({
                 timestampMillis = 123
         )
 
-        val htmlShortSuite = suite.toHtmlShortSuite(id = "testSuite")
+        val htmlFullSuite = suite.toHtmlFullSuite(id = "testSuite")
 
-        it("converts Suite to HtmlShortSuite") {
-            assertThat(htmlShortSuite).isEqualTo(HtmlShortSuite(
+        it("converts Suite to HtmlFullSuite") {
+            assertThat(htmlFullSuite).isEqualTo(HtmlFullSuite(
                     id = "testSuite",
                     passedCount = suite.passedCount,
                     ignoredCount = suite.ignoredCount,
                     failedCount = suite.failedCount,
                     durationMillis = NANOSECONDS.toMillis(suite.durationNanos),
-                    devices = suite.devices.map { it.toHtmlDevice() }
+                    devices = suite.devices.map { it.toHtmlDevice() },
+                    tests = suite.tests.map { it.toHtmlTest() }
             ))
         }
     }

--- a/composer/src/test/kotlin/com/gojuno/composer/html/HtmlShortSuiteSpec.kt
+++ b/composer/src/test/kotlin/com/gojuno/composer/html/HtmlShortSuiteSpec.kt
@@ -1,0 +1,15 @@
+package com.gojuno.composer.html
+
+import org.jetbrains.spek.api.Spek
+import org.jetbrains.spek.api.dsl.describe
+import org.jetbrains.spek.api.dsl.on
+
+class HtmlShortSuiteSpec : Spek({
+    
+    describe("html short suite spec") {
+        
+        on("") {
+            
+        }
+    }
+})

--- a/composer/src/test/kotlin/com/gojuno/composer/html/HtmlTestSpec.kt
+++ b/composer/src/test/kotlin/com/gojuno/composer/html/HtmlTestSpec.kt
@@ -1,0 +1,45 @@
+package com.gojuno.composer.html
+
+import com.gojuno.commander.android.AdbDevice
+import com.gojuno.composer.AdbDeviceTest
+import com.gojuno.composer.testFile
+import org.assertj.core.api.Assertions.assertThat
+import org.jetbrains.spek.api.Spek
+import org.jetbrains.spek.api.dsl.context
+import org.jetbrains.spek.api.dsl.it
+import java.util.concurrent.TimeUnit.NANOSECONDS
+
+class HtmlTestSpec : Spek({
+
+    context("AdbDeviceTest.toHtmlTest") {
+
+        val adbDeviceTest = AdbDeviceTest(
+                adbDevice = AdbDevice(id = "testDevice", online = true),
+                className = "com.gojuno.example.TestClass",
+                testName = "test1",
+                status = AdbDeviceTest.Status.Passed,
+                durationNanos = 23000,
+                logcat = testFile(),
+                files = listOf(testFile(), testFile()),
+                screenshots = listOf(testFile(), testFile())
+        )
+
+        val htmlTest = adbDeviceTest.toHtmlTest()
+
+        it("converts AdbDeviceTest to HtmlTest") {
+            assertThat(htmlTest).isEqualTo(HtmlTest(
+                    packageName = "com.gojuno.example",
+                    className = "TestClass",
+                    name = adbDeviceTest.testName,
+                    status = HtmlTest.Status.Passed,
+                    durationMillis = NANOSECONDS.toMillis(adbDeviceTest.durationNanos),
+                    stacktrace = null,
+                    logcatPath = adbDeviceTest.logcat.path,
+                    filePaths = adbDeviceTest.files.map { it.path },
+                    screenshotsPaths = adbDeviceTest.screenshots.map { it.path },
+                    deviceId = adbDeviceTest.adbDevice.id,
+                    properties = emptyMap()
+            ))
+        }
+    }
+})

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -6,6 +6,7 @@ ext.versions = [
         commander        : '0.1.1',
         apacheCommonsIo  : '2.5',
         apacheCommonsLang: '3.5',
+        gson             : '2.8.0',
 
         junit            : '4.12',
         junitPlatform    : '1.0.0-M3',
@@ -24,6 +25,7 @@ ext.libraries = [
         commanderAndroid       : "com.gojuno.commander:android:$versions.commander",
         apacheCommonsIo        : "commons-io:commons-io:$versions.apacheCommonsIo",
         apacheCommonsLang      : "org.apache.commons:commons-lang3:$versions.apacheCommonsLang",
+        gson                   : "com.google.code.gson:gson:$versions.gson",
 
         junit                  : "junit:junit:$versions.junit",
         spek                   : "org.jetbrains.spek:spek-api:$versions.spek",

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Wed Apr 26 16:35:21 YEKT 2017
+#Wed Apr 05 19:47:52 MSK 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-3.4-bin.zip

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Wed Apr 05 19:47:52 MSK 2017
+#Wed Apr 26 16:35:21 YEKT 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-3.4-all.zip


### PR DESCRIPTION
Part of #11.

@ming13, @dmitry-novikov PTAL — it's core of implementation, no tests yet since, as I've said I had to "duplicate" some classes like Test/Suite/Device across different layers, I now have an idea to divide Composer into separate (in code) pieces:

* Instrumentation level — parses instrumentation output, constructs very basic `Test` entity.
* Adb device test run level — uses Instrumentation level, constructs more sophisticated `Test` and `TestRun` entities that have not only basic test info but also screenshots, files and some meta info.
* Core business logic level — uses Adb device test run level and isolates other components like JUnit4 report generator and HTML report generator from adb level by converting results into own data classes.

Then JUnit4 and HTML reports can be completely unaware of underlying details of execution.