### PR TITLE
Build Docker image to speedup local runs of ci/build.sh.

### DIFF
--- a/ci/build.sh
+++ b/ci/build.sh
@@ -10,24 +10,28 @@ pushd "$PROJECT_DIR"
 # Files created in mounted volume by container should have same owner as host machine user to prevent chmod problems.
 USER_ID=`id -u $USER`
 
-BUILD_COMMAND="set -xe && "
-BUILD_COMMAND+="apt-get update && apt-get --assume-yes install git curl && "
-BUILD_COMMAND+="curl -sL https://deb.nodesource.com/setup_7.x | bash - && apt-get install -y nodejs && "
-
 if [ "$USER_ID" == "0" ]; then
     echo "Warning: running as r00t."
-else
-    BUILD_COMMAND+="apt-get --assume-yes install sudo && "
-    BUILD_COMMAND+="groupadd --gid $USER_ID build_user && "
-    BUILD_COMMAND+="useradd --shell /bin/bash --uid $USER_ID --gid $USER_ID --create-home build_user && "
-    BUILD_COMMAND+="sudo --set-home --preserve-env -u build_user "
 fi
 
-# Build HTML app for reports.
-BUILD_COMMAND+="node --version && npm --version && "
-BUILD_COMMAND+="cd /opt/project/html-report && rm -rf node_modules && npm install && npm run build && cd - && "
+docker build -t composer:latest ci/docker
+
+BUILD_COMMAND=""
+
+BUILD_COMMAND+="echo 'Java version:' && java -version && "
+BUILD_COMMAND+="echo 'Node.js version:' && node --version && "
+BUILD_COMMAND+="echo 'npm vesion:' && npm --version && "
+
+# Build HTML report app.
+BUILD_COMMAND+="echo 'Building HTML report app...' && "
+BUILD_COMMAND+="cd /opt/project/html-report && "
+BUILD_COMMAND+="rm -rf node_modules && "
+BUILD_COMMAND+="npm install && "
+BUILD_COMMAND+="npm run build && "
+BUILD_COMMAND+="cd - && "
 
 # Build Composer.
+BUILD_COMMAND+="echo 'Building Composer...' && "
 BUILD_COMMAND+="/opt/project/gradlew "
 BUILD_COMMAND+="--no-daemon --info --stacktrace "
 BUILD_COMMAND+="clean build "
@@ -39,12 +43,13 @@ fi
 BUILD_COMMAND+="--project-dir /opt/project"
 
 docker run \
+--env LOCAL_USER_ID="$USER_ID" \
 --env BINTRAY_USER="$BINTRAY_USER" \
 --env BINTRAY_API_KEY="$BINTRAY_API_KEY" \
 --env BINTRAY_GPG_PASSPHRASE="$BINTRAY_GPG_PASSPHRASE" \
 --volume `"pwd"`:/opt/project \
 --rm \
-openjdk:8u121-jdk \
+composer:latest \
 bash -c "$BUILD_COMMAND"
 
 popd

--- a/ci/docker/Dockerfile
+++ b/ci/docker/Dockerfile
@@ -1,0 +1,12 @@
+FROM openjdk:8u121-jdk
+
+MAINTAINER Juno Composer Team
+
+RUN apt-get update && \
+    apt-get --assume-yes install git curl sudo && \
+    curl -sL https://deb.nodesource.com/setup_7.x | bash - && apt-get install --assume-yes nodejs
+
+# Entrypoint script will allow us run as non-root in the container.
+COPY entrypoint.sh /usr/local/bin/entrypoint.sh
+RUN chmod +x /usr/local/bin/entrypoint.sh
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]

--- a/ci/docker/entrypoint.sh
+++ b/ci/docker/entrypoint.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+set -xe
+
+# See https://denibertovic.com/posts/handling-permissions-with-docker-volumes/
+
+# Add local user.
+# Either use the LOCAL_USER_ID if passed in at runtime or fallback to 9001.
+USER_ID=${LOCAL_USER_ID:-9001}
+
+echo "Starting with UID : $USER_ID"
+groupadd --gid $USER_ID build_user
+useradd --shell /bin/bash --uid $USER_ID --gid $USER_ID --comment "User for container" --create-home build_user
+
+# Run original docker run command as build_user.
+sudo --set-home --preserve-env -u build_user "$@"


### PR DESCRIPTION
This will allow you to skip installation of nodejs, npm and other utils if you've already built project.