### PR TITLE
Added the ability to pass in device ids to filter the execution on those devices only 

### DIFF
--- a/composer/src/main/kotlin/com/gojuno/composer/Args.kt
+++ b/composer/src/main/kotlin/com/gojuno/composer/Args.kt
@@ -92,7 +92,7 @@ private class JCommanderArgs {
             names = arrayOf("--devices"),
             required = false,
             variableArity = true,
-            description = "Connected devices that will be used to run tests against. Usage example: `--devices emulator-5554 emulator-5556`."
+            description = "Connected devices/emulators that will be used to run tests against. If not passed — tests will run on all connected devices/emulators. Usage example: `--devices emulator-5554 emulator-5556`."
     )
     var devices: List<String>? = null
 }

--- a/composer/src/main/kotlin/com/gojuno/composer/Args.kt
+++ b/composer/src/main/kotlin/com/gojuno/composer/Args.kt
@@ -13,7 +13,8 @@ data class Args(
         val shard: Boolean,
         val outputDirectory: String,
         val instrumentationArguments: List<Pair<String, String>>,
-        val verboseOutput: Boolean
+        val verboseOutput: Boolean,
+        val devices: List<String>
 )
 
 // No way to share array both for runtime and annotation without reflection.
@@ -86,6 +87,14 @@ private class JCommanderArgs {
             description = "Either `true` or `false` to enable/disable verbose output for Swarmer. `false` by default."
     )
     var verboseOutput: Boolean? = null
+
+    @Parameter(
+            names = arrayOf("--devices"),
+            required = false,
+            variableArity = true,
+            description = "Connected devices that will be used to run tests against. Usage example: `--devices emulator-5554 emulator-5556`."
+    )
+    var devices: List<String>? = null
 }
 
 fun parseArgs(rawArgs: Array<String>): Args {
@@ -119,7 +128,8 @@ fun parseArgs(rawArgs: Array<String>): Args {
                         }
                     }
                 },
-                verboseOutput = jCommanderArgs.verboseOutput ?: false
+                verboseOutput = jCommanderArgs.verboseOutput ?: false,
+                devices = jCommanderArgs.devices ?: emptyList()
         )
     }
 }

--- a/composer/src/main/kotlin/com/gojuno/composer/Main.kt
+++ b/composer/src/main/kotlin/com/gojuno/composer/Main.kt
@@ -39,6 +39,11 @@ fun main(rawArgs: Array<String>) {
 
     val suites: List<Suite> = connectedAdbDevices()
             .map {
+                it.filter { args.devices.isEmpty() || args.devices.contains(it.id) }.apply {
+                    it
+                }
+            }
+            .map {
                 it.filter { it.online }.apply {
                     if (isEmpty()) {
                         exit(Exit.NoDevicesAvailableForTests)

--- a/composer/src/main/kotlin/com/gojuno/composer/Main.kt
+++ b/composer/src/main/kotlin/com/gojuno/composer/Main.kt
@@ -39,9 +39,7 @@ fun main(rawArgs: Array<String>) {
 
     val suites: List<Suite> = connectedAdbDevices()
             .map {
-                it.filter { args.devices.isEmpty() || args.devices.contains(it.id) }.apply {
-                    it
-                }
+                it.filter { args.devices.isEmpty() || args.devices.contains(it.id) }
             }
             .map {
                 it.filter { it.online }.apply {

--- a/composer/src/main/kotlin/com/gojuno/composer/Main.kt
+++ b/composer/src/main/kotlin/com/gojuno/composer/Main.kt
@@ -39,7 +39,10 @@ fun main(rawArgs: Array<String>) {
 
     val suites: List<Suite> = connectedAdbDevices()
             .map {
-                it.filter { args.devices.isEmpty() || args.devices.contains(it.id) }
+                when (args.devices.isEmpty()) {
+                    true -> it
+                    false -> it.filter { args.devices.contains(it.id) }
+                }
             }
             .map {
                 it.filter { it.online }.apply {

--- a/composer/src/test/kotlin/com/gojuno/composer/ArgsSpec.kt
+++ b/composer/src/test/kotlin/com/gojuno/composer/ArgsSpec.kt
@@ -29,7 +29,8 @@ class ArgsSpec : Spek({
                     shard = true,
                     outputDirectory = "composer-output",
                     instrumentationArguments = emptyList(),
-                    verboseOutput = false
+                    verboseOutput = false,
+                    devices = emptyList()
             ))
         }
     }
@@ -77,5 +78,29 @@ class ArgsSpec : Spek({
                 }
             }
         }
+    }
+
+    context("parse args with passed --devices") {
+
+        val args by memoized {
+            parseArgs(rawArgsWithOnlyRequiredFields + arrayOf("--devices", "emulator-5554"))
+        }
+
+        it("parses correctly device ids") {
+            assertThat(args.devices).isEqualTo(listOf("emulator-5554"))
+        }
+
+    }
+
+    context("parse args with passed two --devices") {
+
+        val args by memoized {
+            parseArgs(rawArgsWithOnlyRequiredFields + arrayOf("--devices", "emulator-5554", "emulator-5556"))
+        }
+
+        it("parses correctly two device ids") {
+            assertThat(args.devices).isEqualTo(listOf("emulator-5554", "emulator-5556"))
+        }
+
     }
 })


### PR DESCRIPTION
Ability to filter execution on provided emulator/device ids. 
Usage: `--devices emulator-5554` or `--devices emulator-5554 emulator-5556 ...`