### PR TITLE
Add user-friendly error message for "Unable to find instrumentation info".

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,9 +4,9 @@
 *.iml
 .DS_Store
 build/
-artifacts/
+/artifacts
 /captures
-gradle/local.properties
+/gradle/local.properties
 /docs
 
 # Share code style.
@@ -15,5 +15,5 @@ gradle/local.properties
 # Html viewer rules
 node_modules/
 npm-debug.log*
-test/
-composer/src/main/resources/html-report/
+/test/
+/composer/src/main/resources/html-report/

--- a/composer/src/test/resources/instrumentation-output-unable-to-find-instrumentation-info.txt
+++ b/composer/src/test/resources/instrumentation-output-unable-to-find-instrumentation-info.txt
@@ -1,0 +1,10 @@
+INSTRUMENTATION_STATUS: id=ActivityManagerService
+INSTRUMENTATION_STATUS: Error=Unable to find instrumentation info for: ComponentInfo{com.composer.example/com.composer.example.ExampleAndroidJUnitRunner}
+INSTRUMENTATION_STATUS_CODE: -1
+android.util.AndroidException: INSTRUMENTATION_FAILED: com.composer.example/com.composer.example.ExampleAndroidJUnitRunner
+	at com.android.commands.am.Am.runInstrument(Am.java:1121)
+	at com.android.commands.am.Am.onRun(Am.java:374)
+	at com.android.internal.os.BaseCommand.run(BaseCommand.java:47)
+	at com.android.commands.am.Am.main(Am.java:103)
+	at com.android.internal.os.RuntimeInit.nativeFinishInit(Native Method)
+	at com.android.internal.os.RuntimeInit.main(RuntimeInit.java:257)


### PR DESCRIPTION
Should help users resolve the issue much more quickly rather than staring at weird `NumberFormatException`.

See #79.