### PR TITLE
add filtering with device pattern

### DIFF
--- a/composer/src/main/kotlin/com/gojuno/composer/Args.kt
+++ b/composer/src/main/kotlin/com/gojuno/composer/Args.kt
@@ -100,7 +100,7 @@ private class JCommanderArgs {
     @Parameter(
             names = arrayOf("--device-pattern"),
             required = false,
-            description = "Connected devices/emulators that will be used to run tests against. If not passed — tests will run on all connected devices/emulators. Usage example: `--device-pattern \"somePatterns\"`."
+            description = "Connected devices/emulators that will be used to run tests against. If not passed — tests will run on all connected devices/emulators. If `--devices` and `device-pattern` are passed, `--devices` is used. Usage example: `--device-pattern \"somePatterns\"`."
     )
     var devicePattern: String? = null
 }

--- a/composer/src/main/kotlin/com/gojuno/composer/Args.kt
+++ b/composer/src/main/kotlin/com/gojuno/composer/Args.kt
@@ -16,13 +16,7 @@ data class Args(
         val verboseOutput: Boolean,
         val devices: List<String>,
         val devicePattern: String
-) {
-    fun validateArguments() {
-        if(!this.devicePattern.isEmpty() && !this.devices.isEmpty()) {
-            throw IllegalArgumentException("Specifying both --devices and --device-pattern is prohibited.")
-        }
-    }
-}
+)
 
 // No way to share array both for runtime and annotation without reflection.
 private val PARAMETER_HELP_NAMES = setOf("--help", "-help", "help", "-h")
@@ -111,6 +105,12 @@ private class JCommanderArgs {
     var devicePattern: String? = null
 }
 
+private fun validateArguments(args: Args) {
+    if(!args.devicePattern.isEmpty() && !args.devices.isEmpty()) {
+        throw IllegalArgumentException("Specifying both --devices and --device-pattern is prohibited.")
+    }
+}
+
 fun parseArgs(rawArgs: Array<String>): Args {
     if (PARAMETER_HELP_NAMES.firstOrNull { rawArgs.contains(it) } != null) {
         JCommander(JCommanderArgs()).usage()
@@ -145,6 +145,6 @@ fun parseArgs(rawArgs: Array<String>): Args {
                 verboseOutput = jCommanderArgs.verboseOutput ?: false,
                 devices = jCommanderArgs.devices ?: emptyList(),
                 devicePattern = jCommanderArgs.devicePattern ?: ""
-        ).apply { validateArguments() }
-    }
+        )
+    }.apply { validateArguments(this) }
 }

--- a/composer/src/main/kotlin/com/gojuno/composer/Args.kt
+++ b/composer/src/main/kotlin/com/gojuno/composer/Args.kt
@@ -2,6 +2,7 @@ package com.gojuno.janulator
 
 import com.beust.jcommander.JCommander
 import com.beust.jcommander.Parameter
+import com.beust.jcommander.ParameterException
 import com.gojuno.composer.Exit
 import com.gojuno.composer.exit
 
@@ -93,16 +94,24 @@ private class JCommanderArgs {
             names = arrayOf("--devices"),
             required = false,
             variableArity = true,
-            description = "Connected devices/emulators that will be used to run tests against. If not passed — tests will run on all connected devices/emulators. Usage example: `--devices emulator-5554 emulator-5556`."
+            description = "Connected devices/emulators that will be used to run tests against. If not passed — tests will run on all connected devices/emulators. Can't pass `--devices` with `--device-pattern`. Usage example: `--devices emulator-5554 emulator-5556`."
     )
     var devices: List<String>? = null
 
     @Parameter(
             names = arrayOf("--device-pattern"),
             required = false,
-            description = "Connected devices/emulators that will be used to run tests against. If not passed — tests will run on all connected devices/emulators. Usage example: `--device-pattern \"somePatterns\"`."
+            description = "Connected devices/emulators that will be used to run tests against. If not passed — tests will run on all connected devices/emulators. Can't pass `--device-pattern` with `--devices`. Usage example: `--device-pattern \"somePatterns\"`."
     )
     var devicePattern: String? = null
+}
+
+private fun validateArguments(args: Args): Args{
+    if(!args.devicePattern.isEmpty() && !args.devices.isEmpty()) {
+        throw ParameterException("Can't pass both --devices and --device-pattern at the same time.")
+    }
+
+    return args
 }
 
 fun parseArgs(rawArgs: Array<String>): Args {
@@ -140,6 +149,5 @@ fun parseArgs(rawArgs: Array<String>): Args {
                 devices = jCommanderArgs.devices ?: emptyList(),
                 devicePattern = jCommanderArgs.devicePattern ?: ""
         )
-    }
+    }.let { args -> validateArguments(args) }
 }
-

--- a/composer/src/main/kotlin/com/gojuno/composer/Args.kt
+++ b/composer/src/main/kotlin/com/gojuno/composer/Args.kt
@@ -100,7 +100,7 @@ private class JCommanderArgs {
     @Parameter(
             names = arrayOf("--device-pattern"),
             required = false,
-            description = "Connected devices/emulators that will be used to run tests against. If not passed — tests will run on all connected devices/emulators. If `--devices` and `device-pattern` are passed, `--devices` is used. Usage example: `--device-pattern \"somePatterns\"`."
+            description = "Connected devices/emulators that will be used to run tests against. If not passed — tests will run on all connected devices/emulators. Usage example: `--device-pattern \"somePatterns\"`."
     )
     var devicePattern: String? = null
 }

--- a/composer/src/main/kotlin/com/gojuno/composer/Args.kt
+++ b/composer/src/main/kotlin/com/gojuno/composer/Args.kt
@@ -98,9 +98,9 @@ private class JCommanderArgs {
     var devices: List<String>? = null
 
     @Parameter(
-            names = arrayOf("--devicePattern"),
+            names = arrayOf("--device-pattern"),
             required = false,
-            description = "Connected devices/emulators that will be used to run tests against. If not passed — tests will run on all connected devices/emulators. Usage example: `--devicePattern \"somePatterns\"`."
+            description = "Connected devices/emulators that will be used to run tests against. If not passed — tests will run on all connected devices/emulators. Usage example: `--device-pattern \"somePatterns\"`."
     )
     var devicePattern: String? = null
 }

--- a/composer/src/main/kotlin/com/gojuno/composer/Args.kt
+++ b/composer/src/main/kotlin/com/gojuno/composer/Args.kt
@@ -14,7 +14,8 @@ data class Args(
         val outputDirectory: String,
         val instrumentationArguments: List<Pair<String, String>>,
         val verboseOutput: Boolean,
-        val devices: List<String>
+        val devices: List<String>,
+        val devicePattern: String
 )
 
 // No way to share array both for runtime and annotation without reflection.
@@ -95,6 +96,13 @@ private class JCommanderArgs {
             description = "Connected devices/emulators that will be used to run tests against. If not passed — tests will run on all connected devices/emulators. Usage example: `--devices emulator-5554 emulator-5556`."
     )
     var devices: List<String>? = null
+
+    @Parameter(
+            names = arrayOf("--devicePattern"),
+            required = false,
+            description = "Connected devices/emulators that will be used to run tests against. If not passed — tests will run on all connected devices/emulators. Usage example: `--devicePattern \"somePatterns\"`."
+    )
+    var devicePattern: String? = null
 }
 
 fun parseArgs(rawArgs: Array<String>): Args {
@@ -129,7 +137,8 @@ fun parseArgs(rawArgs: Array<String>): Args {
                     }
                 },
                 verboseOutput = jCommanderArgs.verboseOutput ?: false,
-                devices = jCommanderArgs.devices ?: emptyList()
+                devices = jCommanderArgs.devices ?: emptyList(),
+                devicePattern = jCommanderArgs.devicePattern ?: ""
         )
     }
 }

--- a/composer/src/main/kotlin/com/gojuno/composer/Main.kt
+++ b/composer/src/main/kotlin/com/gojuno/composer/Main.kt
@@ -38,10 +38,10 @@ fun main(rawArgs: Array<String>) {
     val gson = Gson()
 
     val suites: List<Suite> = connectedAdbDevices()
-            .map {
+            .map { devices ->
                 when (args.devicePattern.isEmpty()) {
-                    true -> it
-                    false -> Regex(args.devicePattern).let { regex -> devices.filter { regex.matches(it.id) }
+                    true -> devices
+                    false -> Regex(args.devicePattern).let { regex -> devices.filter { regex.matches(it.id) }}
                 }
             }
             .map {

--- a/composer/src/main/kotlin/com/gojuno/composer/Main.kt
+++ b/composer/src/main/kotlin/com/gojuno/composer/Main.kt
@@ -39,15 +39,12 @@ fun main(rawArgs: Array<String>) {
 
     val suites: List<Suite> = connectedAdbDevices()
             .map { devices ->
-                when (args.devicePattern.isEmpty()) {
-                    true -> devices
-                    false -> Regex(args.devicePattern).let { regex -> devices.filter { regex.matches(it.id) }}
-                }
-            }
-            .map {
                 when (args.devices.isEmpty()) {
-                    true -> it
-                    false -> it.filter { args.devices.contains(it.id) }
+                    true -> when (args.devicePattern.isEmpty()) {
+                                true -> devices
+                                false -> Regex(args.devicePattern).let { regex -> devices.filter { regex.matches(it.id) }}
+                            }
+                    false -> devices.filter { args.devices.contains(it.id) }
                 }
             }
             .map {

--- a/composer/src/main/kotlin/com/gojuno/composer/Main.kt
+++ b/composer/src/main/kotlin/com/gojuno/composer/Main.kt
@@ -41,7 +41,7 @@ fun main(rawArgs: Array<String>) {
             .map {
                 when (args.devicePattern.isEmpty()) {
                     true -> it
-                    false -> it.filter { Regex(args.devicePattern).matches(it.id) }
+                    false -> Regex(args.devicePattern).let { regex -> devices.filter { regex.matches(it.id) }
                 }
             }
             .map {

--- a/composer/src/main/kotlin/com/gojuno/composer/Main.kt
+++ b/composer/src/main/kotlin/com/gojuno/composer/Main.kt
@@ -39,12 +39,15 @@ fun main(rawArgs: Array<String>) {
 
     val suites: List<Suite> = connectedAdbDevices()
             .map { devices ->
+                when (args.devicePattern.isEmpty()) {
+                    true -> devices
+                    false -> Regex(args.devicePattern).let { regex -> devices.filter { regex.matches(it.id) }}
+                }
+            }
+            .map {
                 when (args.devices.isEmpty()) {
-                    true -> when (args.devicePattern.isEmpty()) {
-                                true -> devices
-                                false -> Regex(args.devicePattern).let { regex -> devices.filter { regex.matches(it.id) }}
-                            }
-                    false -> devices.filter { args.devices.contains(it.id) }
+                    true -> it
+                    false -> it.filter { args.devices.contains(it.id) }
                 }
             }
             .map {

--- a/composer/src/main/kotlin/com/gojuno/composer/Main.kt
+++ b/composer/src/main/kotlin/com/gojuno/composer/Main.kt
@@ -39,6 +39,12 @@ fun main(rawArgs: Array<String>) {
 
     val suites: List<Suite> = connectedAdbDevices()
             .map {
+                when (args.devicePattern.isEmpty()) {
+                    true -> it
+                    false -> it.filter { Regex(args.devicePattern).matches(it.id) }
+                }
+            }
+            .map {
                 when (args.devices.isEmpty()) {
                     true -> it
                     false -> it.filter { args.devices.contains(it.id) }

--- a/composer/src/test/kotlin/com/gojuno/composer/ArgsSpec.kt
+++ b/composer/src/test/kotlin/com/gojuno/composer/ArgsSpec.kt
@@ -105,13 +105,13 @@ class ArgsSpec : Spek({
 
     }
 
-    context("parse args with passed --devicePattern") {
+    context("parse args with passed --device-pattern") {
 
         val args by memoized {
-            parseArgs(rawArgsWithOnlyRequiredFields + arrayOf("--devicePattern", "[abc|def]"))
+            parseArgs(rawArgsWithOnlyRequiredFields + arrayOf("--device-pattern", "[abc|def]"))
         }
 
-        it("parses correctly devicePattern") {
+        it("parses correctly device-pattern") {
             assertThat(args.devicePattern).isEqualTo("[abc|def]")
         }
     }

--- a/composer/src/test/kotlin/com/gojuno/composer/ArgsSpec.kt
+++ b/composer/src/test/kotlin/com/gojuno/composer/ArgsSpec.kt
@@ -1,8 +1,10 @@
 package com.gojuno.composer
 
+import com.beust.jcommander.ParameterException
 import com.gojuno.janulator.Args
 import com.gojuno.janulator.parseArgs
 import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.jetbrains.spek.api.Spek
 import org.jetbrains.spek.api.dsl.context
 import org.jetbrains.spek.api.dsl.it
@@ -115,4 +117,12 @@ class ArgsSpec : Spek({
             assertThat(args.devicePattern).isEqualTo("[abc|def]")
         }
     }
+
+    context("parse args with passed  --devices and --device-pattern") {
+
+        it("raises argument error") {
+            assertThatThrownBy { parseArgs(rawArgsWithOnlyRequiredFields + arrayOf("--device-pattern", "[abc|def]") + arrayOf("--device-pattern", "[abc|def]")) }.isInstanceOf(ParameterException::class.java)
+        }
+    }
+
 })

--- a/composer/src/test/kotlin/com/gojuno/composer/ArgsSpec.kt
+++ b/composer/src/test/kotlin/com/gojuno/composer/ArgsSpec.kt
@@ -30,7 +30,8 @@ class ArgsSpec : Spek({
                     outputDirectory = "composer-output",
                     instrumentationArguments = emptyList(),
                     verboseOutput = false,
-                    devices = emptyList()
+                    devices = emptyList(),
+                    devicePattern = ""
             ))
         }
     }
@@ -102,5 +103,16 @@ class ArgsSpec : Spek({
             assertThat(args.devices).isEqualTo(listOf("emulator-5554", "emulator-5556"))
         }
 
+    }
+
+    context("parse args with passed --devicePattern") {
+
+        val args by memoized {
+            parseArgs(rawArgsWithOnlyRequiredFields + arrayOf("--devicePattern", "[abc|def]"))
+        }
+
+        it("parses correctly devicePattern") {
+            assertThat(args.devicePattern).isEqualTo("[abc|def]")
+        }
     }
 })

--- a/composer/src/test/kotlin/com/gojuno/composer/ArgsSpec.kt
+++ b/composer/src/test/kotlin/com/gojuno/composer/ArgsSpec.kt
@@ -1,6 +1,5 @@
 package com.gojuno.composer
 
-import com.beust.jcommander.ParameterException
 import com.gojuno.janulator.Args
 import com.gojuno.janulator.parseArgs
 import org.assertj.core.api.Assertions.assertThat
@@ -118,10 +117,12 @@ class ArgsSpec : Spek({
         }
     }
 
-    context("parse args with passed  --devices and --device-pattern") {
+    context("parse args with passed --devices and --device-pattern") {
 
         it("raises argument error") {
-            assertThatThrownBy { parseArgs(rawArgsWithOnlyRequiredFields + arrayOf("--device-pattern", "[abc|def]") + arrayOf("--device-pattern", "[abc|def]")) }.isInstanceOf(ParameterException::class.java)
+            assertThatThrownBy { parseArgs(rawArgsWithOnlyRequiredFields + arrayOf("--device-pattern", "[abc|def]") + arrayOf("--devices", "emulator-5554")) }
+                    .isInstanceOf(IllegalArgumentException::class.java)
+                    .hasMessageContaining("Specifying both --devices and --device-pattern is prohibited.")
         }
     }
 


### PR DESCRIPTION
Hi, there

I'd like to add `--devicePattern` as one of the arguments for the composer command.

## a use case
- Connect some devices, include emulators and read devices, to one machine and we'd like to run instrumentation tests with only emulators.
    - The composer already has `--devices` but we should set all serial patterns. I'd like to set the pattern with `Regex` to make script simple.

```
java -jar composer-latest-version.jar \
--apk app/build/outputs/apk/example-debug.apk \
--test-apk app/build/outputs/apk/example-debug-androidTest.apk \
--test-package com.example.test \
--test-runner com.example.test.ExampleTestRunner \
--output-directory artifacts/composer-output \
--instrumentation-arguments key1 value1 key2 value2 \
--devicePattern "emulator.+" <= new
--verbose-output false
```

What do you think?
