### PR TITLE
Spelling Fix.  "Suits"->"Suites"

### DIFF
--- a/html-report/src/components/Suite.js
+++ b/html-report/src/components/Suite.js
@@ -36,7 +36,7 @@ export default class Suite extends Component {
     const data = window.suite;
     return (
       <div className="content margin-top-20">
-        <div className="title-common"><a href={ paths.fromSuiteToIndex }>Suits list</a>/ Suite {data.id}</div>
+        <div className="title-common"><a href={ paths.fromSuiteToIndex }>Suites list</a>/ Suite {data.id}</div>
 
         <SearchBar setSearchResults={ (results) => this.getSearchResults(results) } />
 

--- a/html-report/src/components/SuitesList.js
+++ b/html-report/src/components/SuitesList.js
@@ -6,7 +6,7 @@ export default class SuitesList extends Component {
   render() {
     return (
       <div className="content margin-top-20">
-        <div className="title-common">Suits list</div>
+        <div className="title-common">Suites list</div>
 
         { window.mainData.suites.map((suite) => {
             return (

--- a/html-report/src/components/TestItem.js
+++ b/html-report/src/components/TestItem.js
@@ -18,7 +18,7 @@ export default class TestItem extends Component {
     return (
       <div className="content margin-top-20">
         <div className="title-common vertical-aligned-content">
-          <a href={ paths.fromTestToIndex }>Suits list</a> /
+          <a href={ paths.fromTestToIndex }>Suites list</a> /
           <a href={ paths.fromTestToSuite(data.suite_id) }>Suite { data.suite_id }</a> /
           { data.deviceId }
         </div>


### PR DESCRIPTION
I noticed there was a spelling error in the report, so I fixed the 3 occurrences of it.

<img width="316" alt="screen shot 2017-09-06 at 3 48 44 pm" src="https://user-images.githubusercontent.com/264948/30131512-0dd25718-931b-11e7-8eb5-0e4f5d4ff5cc.png">
