### PR TITLE
Make linefeed OS-agnostic in unit tests

### DIFF
--- a/composer/src/test/kotlin/com/gojuno/composer/InstrumentationSpec.kt
+++ b/composer/src/test/kotlin/com/gojuno/composer/InstrumentationSpec.kt
@@ -21,22 +21,47 @@ class InstrumentationSpec : Spek({
         }
 
         it("emits expected entries") {
-            // We have no control over system time in tests.
-            assertThat(entriesSubscriber.onNextEvents.map { it.copy(timestampNanos = 0) }).isEqualTo(listOf(
-                    InstrumentationEntry(
-                            numTests = 4,
-                            stream = "com.example.test.TestClass:",
-                            id = "AndroidJUnitRunner",
-                            test = "test1",
-                            clazz = "com.example.test.TestClass",
-                            current = 1,
-                            stack = "",
-                            statusCode = StatusCode.Start,
-                            timestampNanos = 0
-                    ),
-                    InstrumentationEntry(
-                            numTests = 4,
-                            stream = """Error in test1(com.example.test.TestClass):
+            var stacktrace = """java.net.UnknownHostException: Test Exception
+at com.example.test.TestClass.test1.1.invoke(TestClass.kt:245)
+at com.example.test.TestClass.test1.1.invoke(TestClass.kt:44)
+at com.example.test.TestClass.test1(TestClass.kt:238)
+at java.lang.reflect.Method.invoke(Native Method)
+at org.junit.runners.model.FrameworkMethod.1.runReflectiveCall(FrameworkMethod.java:50)
+at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
+at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:47)
+at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
+at org.junit.internal.runners.statements.RunBefores.evaluate(RunBefores.java:26)
+at org.junit.rules.ExpectedException.ExpectedExceptionStatement.evaluate(ExpectedException.java:239)
+at com.example.test.utils.LaunchAppRule.apply.1.evaluate(LaunchAppRule.kt:36)
+at com.example.test.utils.RetryRule.runTest(RetryRule.kt:43)
+at com.example.test.utils.RetryRule.access.runTest(RetryRule.kt:14)
+at com.example.test.utils.RetryRule.apply.1.evaluate(RetryRule.kt:29)
+at org.junit.rules.RunRules.evaluate(RunRules.java:20)
+at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:325)
+at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:78)
+at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:57)
+at org.junit.runners.ParentRunner.3.run(ParentRunner.java:290)
+at org.junit.runners.ParentRunner.1.schedule(ParentRunner.java:71)
+at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:288)
+at org.junit.runners.ParentRunner.access.000(ParentRunner.java:58)
+at org.junit.runners.ParentRunner.2.evaluate(ParentRunner.java:268)
+at org.junit.runners.ParentRunner.run(ParentRunner.java:363)
+at org.junit.runners.Suite.runChild(Suite.java:128)
+at org.junit.runners.Suite.runChild(Suite.java:27)
+at org.junit.runners.ParentRunner.3.run(ParentRunner.java:290)
+at org.junit.runners.ParentRunner.1.schedule(ParentRunner.java:71)
+at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:288)
+at org.junit.runners.ParentRunner.access.000(ParentRunner.java:58)
+at org.junit.runners.ParentRunner.2.evaluate(ParentRunner.java:268)
+at org.junit.runners.ParentRunner.run(ParentRunner.java:363)
+at org.junit.runner.JUnitCore.run(JUnitCore.java:137)
+at org.junit.runner.JUnitCore.run(JUnitCore.java:115)
+at android.support.test.internal.runner.TestExecutor.execute(TestExecutor.java:59)
+at android.support.test.runner.JunoAndroidRunner.onStart(JunoAndroidRunner.kt:107)
+at android.app.Instrumentation.InstrumentationThread.run(Instrumentation.java:1932)"""
+            stacktrace = normalizeLinefeed(stacktrace)
+
+            var stream = """Error in test1(com.example.test.TestClass):
 java.net.UnknownHostException: Test Exception
 at com.example.test.TestClass.test1.1.invoke(TestClass.kt:245)
 at com.example.test.TestClass.test1.1.invoke(TestClass.kt:44)
@@ -74,49 +99,30 @@ at org.junit.runner.JUnitCore.run(JUnitCore.java:137)
 at org.junit.runner.JUnitCore.run(JUnitCore.java:115)
 at android.support.test.internal.runner.TestExecutor.execute(TestExecutor.java:59)
 at android.support.test.runner.JunoAndroidRunner.onStart(JunoAndroidRunner.kt:107)
-at android.app.Instrumentation.InstrumentationThread.run(Instrumentation.java:1932)""",
+at android.app.Instrumentation.InstrumentationThread.run(Instrumentation.java:1932)"""
+            stream = normalizeLinefeed(stream)
+
+            // We have no control over system time in tests.
+            assertThat(entriesSubscriber.onNextEvents.map { it.copy(timestampNanos = 0) }).isEqualTo(listOf(
+                    InstrumentationEntry(
+                            numTests = 4,
+                            stream = "com.example.test.TestClass:",
                             id = "AndroidJUnitRunner",
                             test = "test1",
                             clazz = "com.example.test.TestClass",
                             current = 1,
-                            stack = """java.net.UnknownHostException: Test Exception
-at com.example.test.TestClass.test1.1.invoke(TestClass.kt:245)
-at com.example.test.TestClass.test1.1.invoke(TestClass.kt:44)
-at com.example.test.TestClass.test1(TestClass.kt:238)
-at java.lang.reflect.Method.invoke(Native Method)
-at org.junit.runners.model.FrameworkMethod.1.runReflectiveCall(FrameworkMethod.java:50)
-at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
-at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:47)
-at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
-at org.junit.internal.runners.statements.RunBefores.evaluate(RunBefores.java:26)
-at org.junit.rules.ExpectedException.ExpectedExceptionStatement.evaluate(ExpectedException.java:239)
-at com.example.test.utils.LaunchAppRule.apply.1.evaluate(LaunchAppRule.kt:36)
-at com.example.test.utils.RetryRule.runTest(RetryRule.kt:43)
-at com.example.test.utils.RetryRule.access.runTest(RetryRule.kt:14)
-at com.example.test.utils.RetryRule.apply.1.evaluate(RetryRule.kt:29)
-at org.junit.rules.RunRules.evaluate(RunRules.java:20)
-at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:325)
-at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:78)
-at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:57)
-at org.junit.runners.ParentRunner.3.run(ParentRunner.java:290)
-at org.junit.runners.ParentRunner.1.schedule(ParentRunner.java:71)
-at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:288)
-at org.junit.runners.ParentRunner.access.000(ParentRunner.java:58)
-at org.junit.runners.ParentRunner.2.evaluate(ParentRunner.java:268)
-at org.junit.runners.ParentRunner.run(ParentRunner.java:363)
-at org.junit.runners.Suite.runChild(Suite.java:128)
-at org.junit.runners.Suite.runChild(Suite.java:27)
-at org.junit.runners.ParentRunner.3.run(ParentRunner.java:290)
-at org.junit.runners.ParentRunner.1.schedule(ParentRunner.java:71)
-at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:288)
-at org.junit.runners.ParentRunner.access.000(ParentRunner.java:58)
-at org.junit.runners.ParentRunner.2.evaluate(ParentRunner.java:268)
-at org.junit.runners.ParentRunner.run(ParentRunner.java:363)
-at org.junit.runner.JUnitCore.run(JUnitCore.java:137)
-at org.junit.runner.JUnitCore.run(JUnitCore.java:115)
-at android.support.test.internal.runner.TestExecutor.execute(TestExecutor.java:59)
-at android.support.test.runner.JunoAndroidRunner.onStart(JunoAndroidRunner.kt:107)
-at android.app.Instrumentation.InstrumentationThread.run(Instrumentation.java:1932)""",
+                            stack = "",
+                            statusCode = StatusCode.Start,
+                            timestampNanos = 0
+                    ),
+                    InstrumentationEntry(
+                            numTests = 4,
+                            stream = stream,
+                            id = "AndroidJUnitRunner",
+                            test = "test1",
+                            clazz = "com.example.test.TestClass",
+                            current = 1,
+                            stack = stacktrace,
                             statusCode = StatusCode.Failure,
                             timestampNanos = 0
                     ),
@@ -208,13 +214,7 @@ at android.app.Instrumentation.InstrumentationThread.run(Instrumentation.java:19
 
             it("emits expected tests") {
                 // We have no control over system time in tests.
-                assertThat(testsSubscriber.onNextEvents.map { it.copy(durationNanos = 0) }).isEqualTo(listOf(
-                        InstrumentationTest(
-                                index = 1,
-                                total = 4,
-                                className = "com.example.test.TestClass",
-                                testName = "test1",
-                                status = Failed(stacktrace = """java.net.UnknownHostException: Test Exception
+                var stacktrace = """java.net.UnknownHostException: Test Exception
 at com.example.test.TestClass.test1.1.invoke(TestClass.kt:245)
 at com.example.test.TestClass.test1.1.invoke(TestClass.kt:44)
 at com.example.test.TestClass.test1(TestClass.kt:238)
@@ -251,7 +251,16 @@ at org.junit.runner.JUnitCore.run(JUnitCore.java:137)
 at org.junit.runner.JUnitCore.run(JUnitCore.java:115)
 at android.support.test.internal.runner.TestExecutor.execute(TestExecutor.java:59)
 at android.support.test.runner.JunoAndroidRunner.onStart(JunoAndroidRunner.kt:107)
-at android.app.Instrumentation.InstrumentationThread.run(Instrumentation.java:1932)"""),
+at android.app.Instrumentation.InstrumentationThread.run(Instrumentation.java:1932)"""
+
+                stacktrace = normalizeLinefeed(stacktrace)
+                assertThat(testsSubscriber.onNextEvents.map { it.copy(durationNanos = 0) }).isEqualTo(listOf(
+                        InstrumentationTest(
+                                index = 1,
+                                total = 4,
+                                className = "com.example.test.TestClass",
+                                testName = "test1",
+                                status = Failed(stacktrace = stacktrace),
                                 durationNanos = 0
                         ),
                         InstrumentationTest(
@@ -586,26 +595,7 @@ at android.app.Instrumentation.InstrumentationThread.run(Instrumentation.java:19
 
         it("emits expected entries") {
             // We have no control over system time in tests.
-            assertThat(entriesSubscriber.onNextEvents.map { it.copy(timestampNanos = 0) }).isEqualTo(listOf(
-                    InstrumentationEntry(
-                            numTests = 1,
-                            stream = "com.example.test.TestClass:",
-                            id = "AndroidJUnitRunner",
-                            test = "violated",
-                            clazz = "com.example.test.TestClass",
-                            current = 1,
-                            stack = "",
-                            statusCode = StatusCode.Start,
-                            timestampNanos = 0
-                    ),
-                    InstrumentationEntry(
-                            numTests = 1,
-                            stream = "com.example.test.TestClass:",
-                            id = "AndroidJUnitRunner",
-                            test = "violated",
-                            clazz = "com.example.test.TestClass",
-                            current = 1,
-                            stack = """org.junit.AssumptionViolatedException: got: "foo", expected: is "bar"
+            var stacktrace = """org.junit.AssumptionViolatedException: got: "foo", expected: is "bar"
 at org.junit.Assume.assumeThat(Assume.java:95)
 at com.example.test.TestClass.violated(TestClass.java:22)
 at java.lang.reflect.Method.invoke(Native Method)
@@ -634,7 +624,29 @@ at org.junit.runner.JUnitCore.run(JUnitCore.java:137)
 at org.junit.runner.JUnitCore.run(JUnitCore.java:115)
 at android.support.test.internal.runner.TestExecutor.execute(TestExecutor.java:58)
 at android.support.test.runner.AndroidJUnitRunner.onStart(AndroidJUnitRunner.java:375)
-at android.app.Instrumentation${'$'}InstrumentationThread.run(Instrumentation.java:2074)""",
+at android.app.Instrumentation${'$'}InstrumentationThread.run(Instrumentation.java:2074)"""
+            stacktrace = normalizeLinefeed(stacktrace)
+
+            assertThat(entriesSubscriber.onNextEvents.map { it.copy(timestampNanos = 0) }).isEqualTo(listOf(
+                    InstrumentationEntry(
+                            numTests = 1,
+                            stream = "com.example.test.TestClass:",
+                            id = "AndroidJUnitRunner",
+                            test = "violated",
+                            clazz = "com.example.test.TestClass",
+                            current = 1,
+                            stack = "",
+                            statusCode = StatusCode.Start,
+                            timestampNanos = 0
+                    ),
+                    InstrumentationEntry(
+                            numTests = 1,
+                            stream = "com.example.test.TestClass:",
+                            id = "AndroidJUnitRunner",
+                            test = "violated",
+                            clazz = "com.example.test.TestClass",
+                            current = 1,
+                            stack = stacktrace,
                             statusCode = StatusCode.AssumptionFailure,
                             timestampNanos = 0
                     )
@@ -659,13 +671,7 @@ at android.app.Instrumentation${'$'}InstrumentationThread.run(Instrumentation.ja
             }
 
             it("emits expected tests") {
-                assertThat(testsSubscriber.onNextEvents.map { it.copy(durationNanos = 0) }).isEqualTo(listOf(
-                        InstrumentationTest(
-                                index = 1,
-                                total = 1,
-                                className = "com.example.test.TestClass",
-                                testName = "violated",
-                                status = Ignored(stacktrace = """org.junit.AssumptionViolatedException: got: "foo", expected: is "bar"
+                var stacktrace = """org.junit.AssumptionViolatedException: got: "foo", expected: is "bar"
 at org.junit.Assume.assumeThat(Assume.java:95)
 at com.example.test.TestClass.violated(TestClass.java:22)
 at java.lang.reflect.Method.invoke(Native Method)
@@ -694,7 +700,15 @@ at org.junit.runner.JUnitCore.run(JUnitCore.java:137)
 at org.junit.runner.JUnitCore.run(JUnitCore.java:115)
 at android.support.test.internal.runner.TestExecutor.execute(TestExecutor.java:58)
 at android.support.test.runner.AndroidJUnitRunner.onStart(AndroidJUnitRunner.java:375)
-at android.app.Instrumentation${'$'}InstrumentationThread.run(Instrumentation.java:2074)"""),
+at android.app.Instrumentation${'$'}InstrumentationThread.run(Instrumentation.java:2074)"""
+                stacktrace = normalizeLinefeed(stacktrace)
+                assertThat(testsSubscriber.onNextEvents.map { it.copy(durationNanos = 0) }).isEqualTo(listOf(
+                        InstrumentationTest(
+                                index = 1,
+                                total = 1,
+                                className = "com.example.test.TestClass",
+                                testName = "violated",
+                                status = Ignored(stacktrace = stacktrace),
                                 durationNanos = 0L
                         )
                 ))
@@ -723,4 +737,3 @@ at android.app.Instrumentation${'$'}InstrumentationThread.run(Instrumentation.ja
         }
     }
 })
-

--- a/composer/src/test/kotlin/com/gojuno/composer/JUnitReportSpec.kt
+++ b/composer/src/test/kotlin/com/gojuno/composer/JUnitReportSpec.kt
@@ -12,6 +12,8 @@ import java.util.concurrent.TimeUnit.SECONDS
 
 class JUnitReportSpec : Spek({
 
+    val LF = System.getProperty("line.separator")
+
     context("write test run result as junit4 report to file") {
 
         val adbDevice by memoized { AdbDevice(id = "testDevice", online = true) }
@@ -38,7 +40,7 @@ class JUnitReportSpec : Spek({
                                             adbDevice = adbDevice,
                                             className = "test.class.name2",
                                             testName = "test2",
-                                            status = Failed(stacktrace = "multi\nline\nstacktrace"),
+                                            status = Failed(stacktrace = "multi${LF}line${LF}stacktrace"),
                                             durationNanos = MILLISECONDS.toNanos(3250),
                                             logcat = testFile(),
                                             files = emptyList(),
@@ -68,7 +70,7 @@ class JUnitReportSpec : Spek({
                                             adbDevice = adbDevice,
                                             className = "test.class.name5",
                                             testName = "test5",
-                                            status = Ignored("multi\nline\nstacktrace"),
+                                            status = Ignored("multi${LF}line${LF}stacktrace"),
                                             durationNanos = SECONDS.toNanos(0),
                                             logcat = testFile(),
                                             files = emptyList(),
@@ -86,7 +88,7 @@ class JUnitReportSpec : Spek({
         }
 
         it("produces correct xml report") {
-            assertThat(outputFile.readText()).isEqualTo("""
+            var expected = """
                 <?xml version="1.0" encoding="UTF-8"?>
                 <testsuite name="com.gojuno.test" tests="5" failures="1" errors="0" skipped="2" time="6.25" timestamp="2017-03-22T16:29:10" hostname="localhost">
                 <properties/>
@@ -111,7 +113,9 @@ class JUnitReportSpec : Spek({
                 </testcase>
                 </testsuite>
                 """.trimIndent() + "\n"
-            )
+            expected = normalizeLinefeed(expected)
+            val actual = outputFile.readText()
+            assertThat(actual).isEqualTo(expected)
         }
 
         it("emits completion") {

--- a/composer/src/test/kotlin/com/gojuno/composer/html/HtmlReportSpec.kt
+++ b/composer/src/test/kotlin/com/gojuno/composer/html/HtmlReportSpec.kt
@@ -1,7 +1,10 @@
 package com.gojuno.composer.html
 
 import com.gojuno.commander.android.AdbDevice
-import com.gojuno.composer.*
+import com.gojuno.composer.AdbDeviceTest
+import com.gojuno.composer.Device
+import com.gojuno.composer.Suite
+import com.gojuno.composer.perform
 import com.google.gson.Gson
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.util.Files
@@ -89,7 +92,8 @@ class HtmlReportSpec : Spek({
         fun String.removeEmptyLines() = lines().filter { it.trim() != "" }.joinToString(separator = "\n") { it }
 
         it("creates index html") {
-            var expected = """
+            assertThat(File(outputDir, "index.html").readText().removeEmptyLines()).isEqualTo(
+                    """
                     <!doctype html>
                     <html lang="en">
                       <head>
@@ -110,12 +114,12 @@ class HtmlReportSpec : Spek({
                       </body>
                     </html>
                     """.removeEmptyLines().trimIndent()
-            expected = normalizeLinefeed(expected)
-            assertThat(File(outputDir, "index.html").readText().removeEmptyLines()).isEqualTo(expected)
+            )
         }
 
         it("creates suite html") {
-            var expected = """
+            assertThat(File(File(outputDir, "suites"), "0.html").readText().removeEmptyLines()).isEqualTo(
+                    """
                             <!doctype html>
                             <html lang="en">
                               <head>
@@ -136,12 +140,12 @@ class HtmlReportSpec : Spek({
                               </body>
                             </html>
                             """.removeEmptyLines().trimIndent()
-            expected = normalizeLinefeed(expected)
-            assertThat(File(File(outputDir, "suites"), "0.html").readText().removeEmptyLines()).isEqualTo(expected)
+            )
         }
 
         it("creates html for 1st test") {
-            var expected = """
+            assertThat(File(File(File(File(outputDir, "suites"), "0"), "device1"), "com.gojuno.example1TestClasstest1.html").readText().removeEmptyLines()).isEqualTo(
+                    """
                             <!doctype html>
                             <html lang="en">
                               <head>
@@ -162,12 +166,12 @@ class HtmlReportSpec : Spek({
                               </body>
                             </html>
                             """.removeEmptyLines().trimIndent()
-            expected = normalizeLinefeed(expected)
-            assertThat(File(File(File(File(outputDir, "suites"), "0"), "device1"), "com.gojuno.example1TestClasstest1.html").readText().removeEmptyLines()).isEqualTo(expected)
+            )
         }
 
         it("creates html for 2nd test") {
-            var expected = """
+            assertThat(File(File(File(File(outputDir, "suites"), "0"), "device1"), "com.gojuno.example1TestClasstest2.html").readText().removeEmptyLines()).isEqualTo(
+                    """
                             <!doctype html>
                             <html lang="en">
                               <head>
@@ -188,8 +192,7 @@ class HtmlReportSpec : Spek({
                               </body>
                             </html>
                             """.removeEmptyLines().trimIndent()
-            expected = normalizeLinefeed(expected)
-            assertThat(File(File(File(File(outputDir, "suites"), "0"), "device1"), "com.gojuno.example1TestClasstest2.html").readText().removeEmptyLines()).isEqualTo(expected)
+            )
         }
     }
 

--- a/composer/src/test/kotlin/com/gojuno/composer/html/HtmlReportSpec.kt
+++ b/composer/src/test/kotlin/com/gojuno/composer/html/HtmlReportSpec.kt
@@ -1,10 +1,7 @@
 package com.gojuno.composer.html
 
 import com.gojuno.commander.android.AdbDevice
-import com.gojuno.composer.AdbDeviceTest
-import com.gojuno.composer.Device
-import com.gojuno.composer.Suite
-import com.gojuno.composer.perform
+import com.gojuno.composer.*
 import com.google.gson.Gson
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.util.Files
@@ -92,8 +89,7 @@ class HtmlReportSpec : Spek({
         fun String.removeEmptyLines() = lines().filter { it.trim() != "" }.joinToString(separator = "\n") { it }
 
         it("creates index html") {
-            assertThat(File(outputDir, "index.html").readText().removeEmptyLines()).isEqualTo(
-                    """
+            var expected = """
                     <!doctype html>
                     <html lang="en">
                       <head>
@@ -114,12 +110,12 @@ class HtmlReportSpec : Spek({
                       </body>
                     </html>
                     """.removeEmptyLines().trimIndent()
-            )
+            expected = normalizeLinefeed(expected)
+            assertThat(File(outputDir, "index.html").readText().removeEmptyLines()).isEqualTo(expected)
         }
 
         it("creates suite html") {
-            assertThat(File(File(outputDir, "suites"), "0.html").readText().removeEmptyLines()).isEqualTo(
-                    """
+            var expected = """
                             <!doctype html>
                             <html lang="en">
                               <head>
@@ -140,12 +136,12 @@ class HtmlReportSpec : Spek({
                               </body>
                             </html>
                             """.removeEmptyLines().trimIndent()
-            )
+            expected = normalizeLinefeed(expected)
+            assertThat(File(File(outputDir, "suites"), "0.html").readText().removeEmptyLines()).isEqualTo(expected)
         }
 
         it("creates html for 1st test") {
-            assertThat(File(File(File(File(outputDir, "suites"), "0"), "device1"), "com.gojuno.example1TestClasstest1.html").readText().removeEmptyLines()).isEqualTo(
-                    """
+            var expected = """
                             <!doctype html>
                             <html lang="en">
                               <head>
@@ -166,12 +162,12 @@ class HtmlReportSpec : Spek({
                               </body>
                             </html>
                             """.removeEmptyLines().trimIndent()
-            )
+            expected = normalizeLinefeed(expected)
+            assertThat(File(File(File(File(outputDir, "suites"), "0"), "device1"), "com.gojuno.example1TestClasstest1.html").readText().removeEmptyLines()).isEqualTo(expected)
         }
 
         it("creates html for 2nd test") {
-            assertThat(File(File(File(File(outputDir, "suites"), "0"), "device1"), "com.gojuno.example1TestClasstest2.html").readText().removeEmptyLines()).isEqualTo(
-                    """
+            var expected = """
                             <!doctype html>
                             <html lang="en">
                               <head>
@@ -192,7 +188,8 @@ class HtmlReportSpec : Spek({
                               </body>
                             </html>
                             """.removeEmptyLines().trimIndent()
-            )
+            expected = normalizeLinefeed(expected)
+            assertThat(File(File(File(File(outputDir, "suites"), "0"), "device1"), "com.gojuno.example1TestClasstest2.html").readText().removeEmptyLines()).isEqualTo(expected)
         }
     }
 

--- a/composer/src/test/kotlin/com/gojuno/composer/test.kt
+++ b/composer/src/test/kotlin/com/gojuno/composer/test.kt
@@ -10,3 +10,6 @@ fun testFile(): File = createTempFile().apply { deleteOnExit() }
 fun SpecBody.perform(body: () -> Unit) = beforeEachTest(body)
 
 fun SpecBody.cleanup(body: () -> Unit) = afterEachTest(body)
+
+/** Make a Unix-formatted String compliant with current operating system's newline format */
+fun normalizeLinefeed(str: String): String = str.replace("\n", System.getProperty("line.separator"));


### PR DESCRIPTION
Ensure no tests fail due to \n differs to \r\n on Windows,
while maintaining Linux/MacOS compatibility

*edit*: Might hold off the merge until I've verified that tests in `HtmlReportSpec` passes. I'm struggling to generate `app.min.js` (or you can verify it on AppVeyor)

*edit 2*: `HtmlReportSpec` have other issues not related to Linefeed or Windows. I believe this PR can be merged