### PR TITLE
Fix NPE when listing files in screenshot folder

### DIFF
--- a/composer/src/main/kotlin/com/gojuno/composer/TestRun.kt
+++ b/composer/src/main/kotlin/com/gojuno/composer/TestRun.kt
@@ -173,7 +173,7 @@ private fun pullTestFiles(adbDevice: AdbDevice, test: InstrumentationTest, outpu
             PulledFiles(
                     files = emptyList(), // TODO: Pull test files.
                     screenshots = screenshotsFolderOnHostMachine.let {
-                        when (it.exists()) {
+                        when (it.exists() && it.listFiles() != null) {
                             true -> it.listFiles().toList()
                             else -> emptyList()
                         }


### PR DESCRIPTION
`listFiles()` may return null which lead to crash:

```
Exception in thread "main" java.lang.IllegalArgumentException: Parameter specified as non-null is null: method kotlin.collections.ArraysKt___ArraysKt.toList, parameter $receiver
        at kotlin.collections.ArraysKt___ArraysKt.toList(_Arrays.kt)
        at com.gojuno.composer.TestRunKt$pullTestFiles$3.call(TestRun.kt:177)
        at com.gojuno.composer.TestRunKt$pullTestFiles$3.call(TestRun.kt)
```