### PR TITLE
Updated handling of crashed application during test run.

### DIFF
--- a/composer/src/main/kotlin/com/gojuno/composer/Instrumentation.kt
+++ b/composer/src/main/kotlin/com/gojuno/composer/Instrumentation.kt
@@ -1,6 +1,8 @@
 package com.gojuno.composer
 
-import com.gojuno.composer.InstrumentationTest.Status.*
+import com.gojuno.composer.InstrumentationTest.Status.Failed
+import com.gojuno.composer.InstrumentationTest.Status.Ignored
+import com.gojuno.composer.InstrumentationTest.Status.Passed
 import rx.Observable
 import java.io.File
 
@@ -61,7 +63,7 @@ private fun String.parseInstrumentationStatusValue(key: String): String = this
         .trim()
 
 private fun String.throwIfError(output: File) = when {
-    contains("INSTRUMENTATION_RESULT: shortMsg=Process crashed") -> {
+    contains("INSTRUMENTATION_RESULT: shortMsg=") -> {
         throw Exception("Application process crashed. Check Logcat output for more details.")
     }
 

--- a/composer/src/test/resources/instrumentation-output-app-crash.txt
+++ b/composer/src/test/resources/instrumentation-output-app-crash.txt
@@ -1,0 +1,12 @@
+INSTRUMENTATION_STATUS: numtests=1
+INSTRUMENTATION_STATUS: stream=
+com.example.test.TestClass:
+INSTRUMENTATION_STATUS: id=AndroidJUnitRunner
+INSTRUMENTATION_STATUS: test=crashTest
+INSTRUMENTATION_STATUS: class=com.example.test.TestClass:
+INSTRUMENTATION_STATUS: current=1
+INSTRUMENTATION_STATUS_CODE: 1
+INSTRUMENTATION_RESULT: shortMsg=java.lang.NullPointerException
+INSTRUMENTATION_RESULT: longMsg=java.lang.NullPointerException: Attempt to invoke virtual method 'void java.util.logging.Logger.log(java.util.logging.Level, java.lang.String, java.lang.Throwable)' on a null object reference
+
+INSTRUMENTATION_CODE: 0


### PR DESCRIPTION
Basically, thats it, fixes #121) 

It appears that crashes are reported differently under different OS revisions. I've got another example with `shortMsg=Native crash` on Lollipop, too. So the common thing here is `shortMsg` and it should be sufficient to treat it as crash.

With this PR test run will fail, but the excluded tests will remain silently ignored.
Seems to me that possible nicer option would be to refactor error handling the way that other tests are reported as `ignored`. On the other hand it will be confusing, too.

IMO we can live with such solution until we integrate test orchestrator or our own test runner which will run tests independently and allow to restart crashed application and failed test.

WDYT @artem-zinnatullin ?