### PR TITLE
Add search bar and filters for logcat output

### DIFF
--- a/composer/src/main/kotlin/com/gojuno/composer/html/HtmlReport.kt
+++ b/composer/src/main/kotlin/com/gojuno/composer/html/HtmlReport.kt
@@ -95,7 +95,7 @@ fun generateLogcatHtml(logcatOutput: File): String = when (logcatOutput.exists()
     true -> logcatOutput
             .readLines()
             .map { line -> """<div class="log__${cssClassForLogcatLine(line)}">${StringEscapeUtils.escapeXml11(line)}</div>""" }
-            .fold(StringBuilder("""<div class="content"><div class="card log">""")) { stringBuilder, line ->
+            .fold(StringBuilder("""<div id="static_logs" class="content"><div class="card log">""")) { stringBuilder, line ->
                 stringBuilder.appendln(line)
             }
             .appendln("""</div></div>""")

--- a/html-report/layout/log-container.html
+++ b/html-report/layout/log-container.html
@@ -1,4 +1,4 @@
-<div class="content">
+<div id="static_logs" class="content">
   <div class="card log">
     ${log_entries}
   </div>

--- a/html-report/src/components/LogContainer.js
+++ b/html-report/src/components/LogContainer.js
@@ -1,0 +1,88 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import cx from 'classnames';
+import LogFilter from './LogFilter'
+
+export default class LogContainer extends Component {
+  static propTypes = {
+    logcatPath: PropTypes.string
+  };
+
+  state = {
+    logs: [],
+    results: [],
+    loading: true,
+    hide: false
+  }
+
+  componentDidMount() {
+      this.readSingleFile(this.props.logcatPath)
+  }
+
+  readSingleFile(path) {
+    fetch(path)
+      .then(response =>
+        response.status == 200
+        ? response.text()
+        : this.setState({hide: true, loading: false})
+      )
+      .then(text => text.split('\n'))
+      .then(lines => lines.map(line =>
+        Object.assign({level: this.logLevel(line), line: line, key: this.hashCode(line)}))
+      )
+      .then(logs => {
+        this.setState({logs: logs, results: logs, loading: false});
+        window.document.getElementById("static_logs").remove();
+      })
+      .catch(error => this.setState({hide: true, loading: false}))
+  };
+
+  getSearchResults(results) {
+    this.setState({ results: results });
+  }
+
+  hashCode(str) {
+    return str.split('').reduce((prevHash, currVal) =>
+      (((prevHash << 5) - prevHash) + currVal.charCodeAt(0))|0, 0);
+  }
+
+  logLevel(line) {
+    let match = line.match(/^[^A-Z]*?([A-Z])/);
+    if (match == null || match.length < 2) {
+        return "default";
+    }
+    switch (match[1]) {
+      case "V": return "verbose";
+      case "D": return "debug";
+      case "I": return "info";
+      case "W": return "warning";
+      case "E": return "error";
+      case "A": return "assert";
+      default: return "default";
+    }
+  }
+
+  render() {
+    return this.state.hide
+    ? (<div></div>)
+    : (
+      <div className="margin-top-20">
+        <LogFilter
+          setSearchResults={ (results) => this.getSearchResults(results) }
+          data={this.state.logs}
+          />
+        { !this.state.loading &&
+        <div className="card log">
+          { this.state.results.map((entry, i) => {
+            return (
+              <div key={ entry.key } className={"log__" + entry.level}>
+                {entry.line}
+              </div>
+            )
+          })
+          }
+        </div>}
+      </div>
+    );
+  }
+}

--- a/html-report/src/components/LogFilter.js
+++ b/html-report/src/components/LogFilter.js
@@ -1,0 +1,37 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import cx from 'classnames';
+import SearchBar from './SearchBar';
+import LogFilterButton from './LogFilterButton';
+
+const SEARCH_FIELDS = ['level', 'line'];
+const SEARCH_REF = 'line';
+export default class LogFilter extends Component {
+  static propTypes = {
+    setSearchResults: PropTypes.func,
+    data: PropTypes.array
+  };
+
+  render() {
+    return (
+      <div>
+        <div className="card">
+          <div className="title-common">LOGS</div>
+          <LogFilterButton onClick={ () => this.performFilterSearch("level:verbose") } text="Verbose" disabled={ !!!this.props.data.length } />
+          <LogFilterButton onClick={ () => this.performFilterSearch("level:debug") } text="Debug" disabled={ !!!this.props.data.length } />
+          <LogFilterButton onClick={ () => this.performFilterSearch("level:info") } text="Info" disabled={ !!!this.props.data.length } />
+          <LogFilterButton onClick={ () => this.performFilterSearch("level:warning") } text="Warning" disabled={ !!!this.props.data.length } />
+          <LogFilterButton onClick={ () => this.performFilterSearch("level:error") } text="Error" disabled={ !!!this.props.data.length } />
+          <LogFilterButton onClick={ () => this.performFilterSearch("level:assert") } text="Assert" disabled={ !!!this.props.data.length } />
+        </div>
+        <SearchBar
+          setSearchResults={this.props.setSearchResults}
+          searchFields={SEARCH_FIELDS}
+          searchRef={SEARCH_REF}
+          data={this.props.data}
+          setPerformFilterSearchCallback={ callback => (this.performFilterSearch = callback) }
+          />
+      </div>
+    );
+  }
+}

--- a/html-report/src/components/LogFilterButton.js
+++ b/html-report/src/components/LogFilterButton.js
@@ -1,0 +1,13 @@
+import React from 'react';
+
+const LogFilterButton = ({text, disabled, onClick}) => (
+  <button
+    className="button secondary margin-right-10"
+    onClick={ onClick }
+    disabled={ disabled }
+    >
+    {text}
+  </button>
+);
+
+export default LogFilterButton;

--- a/html-report/src/components/Suite.js
+++ b/html-report/src/components/Suite.js
@@ -3,7 +3,7 @@ import cx from 'classnames';
 import randomColor from 'randomcolor';
 import convertTime from './../utils/convertTime';
 import paths from './../utils/paths';
-import SearchBar from './SearchBar';
+import SuiteFilter from './SuiteFilter';
 
 export default class Suite extends Component {
   state = {
@@ -38,7 +38,7 @@ export default class Suite extends Component {
       <div className="content margin-top-20">
         <div className="title-common"><a href={ paths.fromSuiteToIndex }>Suites list</a>/ Suite {data.id}</div>
 
-        <SearchBar setSearchResults={ (results) => this.getSearchResults(results) } />
+        <SuiteFilter setSearchResults={ (results) => this.getSearchResults(results) } />
 
         <div className="card">
           <div className="vertical-aligned-content title-common">

--- a/html-report/src/components/SuiteFilter.js
+++ b/html-report/src/components/SuiteFilter.js
@@ -1,0 +1,51 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import cx from 'classnames';
+import convertTime from './../utils/convertTime'
+import SearchBar from './SearchBar';
+
+const SEARCH_FIELDS = ['package_name', 'class_name', 'name', 'id', 'status'];
+const SEARCH_REF = 'id';
+export default class SuiteFilter extends Component {
+  static propTypes = {
+    setSearchResults: PropTypes.func
+  };
+
+  performFilterSearch = (query) => {
+    this.searchBar.performFilterSearch(query)
+  };
+
+  render() {
+    const data = window.suite;
+
+    return (
+      <div>
+        <div className="row justify-between">
+          <div className="card card-info filter-card" onClick={ () => this.performFilterSearch('status:passed') }>
+            <div className="text-sub-title-light">Passed</div>
+            <div className="card-info__content status-passed">{ data.passed_count }</div>
+          </div>
+          <div className="card card-info filter-card" onClick={ () => this.performFilterSearch('status:failed') }>
+            <div className="text-sub-title-light">Failed</div>
+            <div className="card-info__content status-failed">{ data.failed_count }</div>
+          </div>
+          <div className="card card-info filter-card" onClick={ () => this.performFilterSearch('status:ignored') }>
+            <div className="text-sub-title-light">Ignored</div>
+            <div className="card-info__content status-ignored">{ data.ignored_count }</div>
+          </div>
+          <div className="card card-info">
+            <div className="text-sub-title-light">Duration</div>
+            <div className="card-info__content">{ convertTime(data.duration_millis) }</div>
+          </div>
+        </div>
+        <SearchBar
+          setSearchResults={this.props.setSearchResults}
+          searchFields={SEARCH_FIELDS}
+          searchRef={SEARCH_REF}
+          data={data.tests}
+          setPerformFilterSearchCallback={ callback => (this.performFilterSearch = callback) }
+          />
+      </div>
+    )
+  }
+}

--- a/html-report/src/components/TestItem.js
+++ b/html-report/src/components/TestItem.js
@@ -2,14 +2,21 @@ import React, { Component } from 'react';
 import cx from 'classnames';
 import convertTime from './../utils/convertTime'
 import paths from './../utils/paths'
+import LogContainer from './LogContainer'
 
 export default class TestItem extends Component {
+
+  state = {
+    data: window.test,
+  };
+
   componentWillMount() {
     document.title = `Test ${window.test.name}`;
   }
 
   render() {
-    const data = window.test;
+    const data = this.state.data
+
     let statusLabelClass = cx('label', 'margin-right-10', {
       alert: data.status === 'failed',
       success: data.status === 'passed'
@@ -65,6 +72,8 @@ export default class TestItem extends Component {
               }) }
             </ul>
           </div>}
+
+          <LogContainer logcatPath={ this.state.data.logcat_path } />
         </div>
       </div>
     );


### PR DESCRIPTION
There are many ways to approach this.
I decided against adding to the `window.test` object as logcat output can be very large.

I kept the static html generated by the Jar. I just added an id `static_logs` in order to remove it once we load the logs in js.

I made a `LogContainer` component that shows the filters, the search bar and the logs once they are loaded from the file (it replaces the static logs).

I extracted the `SearchBar` component and made it generic and used by `LogFilter` and `SuiteFilter`
