### PR TITLE
HTML report will now render stacktrace, if any

### DIFF
--- a/html-report/src/components/TestItem.js
+++ b/html-report/src/components/TestItem.js
@@ -65,6 +65,11 @@ export default class TestItem extends Component {
               }) }
             </ul>
           </div>}
+
+          { !!data.stacktrace.length && <div className="card">
+            <div className="title-common">Stacktrace</div>
+            <pre className="row" style={ { overflow: 'auto' } }>{ data.stacktrace }</pre>
+          </div>}
         </div>
       </div>
     );


### PR DESCRIPTION
TestItem screen of HTML test report will now display stacktrace data, that was available before in the JavaScript data anyway, but was not displayed

Before:
<img width="1019" alt="screenshot 2018-09-17 21 43 39" src="https://user-images.githubusercontent.com/1147572/45646259-13e58c80-bac3-11e8-9e4f-ec69915fe5b4.png">

After:
<img width="1237" alt="screenshot 2018-09-17 21 43 57" src="https://user-images.githubusercontent.com/1147572/45646263-16e07d00-bac3-11e8-990d-dfd4038e3271.png">
