### PR TITLE
Adding support for Android Test Orchestrator

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,13 @@ Composer shipped as jar, to run it you need JVM 1.8+: `java -jar composer-latest
   * Default: `true`.
   * `False` may be applicable when you run tests conditionally(via annotation/package filters) and empty suite is a valid outcome.
   * Example: `--fail-if-no-tests false`
+* `--with-orchestrator`
+  * Either `true` or `false` to enable/disable running tests via Android Test Orchestrator.
+  * Default: `false`.
+  * When enabled - minimizes shared state and isolates test crashes.
+  * Requires test orchestrator & test services APKs to be installed on device before executing.
+  * More info: https://developer.android.com/training/testing/junit-runner#using-android-test-orchestrator
+  * Example: `--with-orchestrator true`
   
 ##### Example
 
@@ -138,7 +145,8 @@ java -jar composer-latest-version.jar \
 --output-directory artifacts/composer-output \
 --instrumentation-arguments key1 value1 key2 value2 \
 --verbose-output false \
---keep-output-on-exit false
+--keep-output-on-exit false \
+--with-orchestrator false
 ```
 
 ### Download

--- a/composer/src/main/kotlin/com/gojuno/composer/Args.kt
+++ b/composer/src/main/kotlin/com/gojuno/composer/Args.kt
@@ -106,7 +106,15 @@ data class Args(
                 description = "Either `true` or `false` to enable/disable error on empty test suite. True by default.",
                 order = 11
         )
-        var failIfNoTests: Boolean = true
+        var failIfNoTests: Boolean = true,
+
+        @Parameter(
+                names = arrayOf("--with-orchestrator"),
+                required = false,
+                description = "Either `true` or `false` to enable/disable running tests via Android Test Orchestrator. False by default.",
+                order = 12
+        )
+        var runWithOrchestrator: Boolean = false
 )
 
 // No way to share array both for runtime and annotation without reflection.

--- a/composer/src/main/kotlin/com/gojuno/composer/TestRun.kt
+++ b/composer/src/main/kotlin/com/gojuno/composer/TestRun.kt
@@ -44,18 +44,22 @@ fun AdbDevice.runTests(
         instrumentationArguments: String,
         outputDir: File,
         verboseOutput: Boolean,
-        keepOutput: Boolean
+        keepOutput: Boolean,
+        useTestServices: Boolean
 ): Single<AdbDeviceTestRun> {
 
     val adbDevice = this
     val logsDir = File(File(outputDir, "logs"), adbDevice.id)
     val instrumentationOutputFile = File(logsDir, "instrumentation.output")
+    val commandPrefix = if (useTestServices) {
+        "CLASSPATH=$(pm path android.support.test.services) app_process / android.support.test.services.shellexecutor.ShellMain "
+    } else ""
 
     val runTests = process(
             commandAndArgs = listOf(
                     adb,
                     "-s", adbDevice.id,
-                    "shell", "am instrument -w -r $instrumentationArguments $testPackageName/$testRunnerClass"
+                    "shell", "${commandPrefix}am instrument -w -r $instrumentationArguments $testPackageName/$testRunnerClass"
             ),
             timeout = null,
             redirectOutputTo = instrumentationOutputFile,

--- a/composer/src/test/kotlin/com/gojuno/composer/ArgsSpec.kt
+++ b/composer/src/test/kotlin/com/gojuno/composer/ArgsSpec.kt
@@ -30,7 +30,8 @@ class ArgsSpec : Spek({
                     devices = emptyList(),
                     devicePattern = "",
                     installTimeoutSeconds = 120,
-                    failIfNoTests = true
+                    failIfNoTests = true,
+                    runWithOrchestrator = false
             ))
         }
     }
@@ -191,6 +192,17 @@ class ArgsSpec : Spek({
                     assertThat(args.failIfNoTests).isEqualTo(failIfNoTests)
                 }
             }
+        }
+    }
+
+    context("parse args with --with-orchestrator") {
+
+        val args by memoized {
+            parseArgs(rawArgsWithOnlyRequiredFields + "--with-orchestrator")
+        }
+
+        it("parses --with-orchestrator correctly") {
+            assertThat(args.runWithOrchestrator).isEqualTo(true)
         }
     }
 })


### PR DESCRIPTION
This fixes #90, closes #131 and closes #135 

Tested in production - works perfectly, also the report generation

One point of uncertainty - the requirement to install test orchestrator and test services APKs before running the tests. I'm not convinced that this should be something `composer` itself should be concerned with, as those APKs just need to be installed, no parsing is done on them otherwise (as opposed to normal app/test APKs)

The installation can either be done manually ([as described in the official docs](https://developer.android.com/training/testing/junit-runner#using-android-test-orchestrator)) OR, if used with Gradle - with a custom task, something like this:

```gradle
android {
    defaultConfig {
        ...

        testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
        testInstrumentationRunnerArguments clearPackageData: 'true'
    }
    testOptions {
        execution 'ANDROID_TEST_ORCHESTRATOR'
    }
}

dependencies {
    androidTestImplementation 'com.android.support.test:runner:1.0.2'
    androidTestUtil 'com.android.support.test:orchestrator:1.0.2'
}

task installTestUtils() {
    doFirst {
        // Resolve and install all files associated with androidTestUtil configuration, which will be both - test services and the orchestrator APKs
        configurations.androidTestUtil.resolvedConfiguration.files.forEach { filePath ->
            println "Installing ${filePath} ..."
            exec {
                workingDir projectDir
                commandLine 'adb', 'install', '-r', filePath
            }
        }
    }
}
```