### PR TITLE
Install extra APKs if received ( useful for Orchestrator )

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ Composer shipped as jar, to run it you need JVM 1.8+: `java -jar composer-latest
 * `--extra-apks`
   * Apks to be installed for utilities. What you would typically declare in gradle as `androidTestUtil` 
   * Default: empty, only apk and test apk would be installed.
-  * Works great with orchestrator to install orchestrator & test services APKs.
+  * Works great with Orchestrator to install orchestrator & test services APKs.
   * Example: `--extra-apks path/to/apk/first.apk path/to/apk/second.apk`
   
 ##### Example

--- a/README.md
+++ b/README.md
@@ -126,6 +126,11 @@ Composer shipped as jar, to run it you need JVM 1.8+: `java -jar composer-latest
   * Requires test orchestrator & test services APKs to be installed on device before executing.
   * More info: https://developer.android.com/training/testing/junit-runner#using-android-test-orchestrator
   * Example: `--with-orchestrator true`
+* `--extra-apks`
+  * Apks to be installed for utilities. What you would typically declare in gradle as `androidTestUtil` 
+  * Default: empty, only apk and test apk would be installed.
+  * Works great with orchestrator to install orchestrator & test services APKs.
+  * Example: `--extra-apks path/to/apk/first.apk path/to/apk/second.apk`
   
 ##### Example
 

--- a/composer/src/main/kotlin/com/gojuno/composer/Args.kt
+++ b/composer/src/main/kotlin/com/gojuno/composer/Args.kt
@@ -117,13 +117,13 @@ data class Args(
         var runWithOrchestrator: Boolean = false,
 
         @Parameter(
-            names = arrayOf("--orchestrator-apks"),
+            names = arrayOf("--extra-apks"),
             required = false,
             variableArity = true,
-            description = "APKs for orchestrator ( orchestrator and test-services )",
+            description = "Extra APKs you would usually put on androidTestUtil",
             order = 13
         )
-        var orchestratorApks: List<String> = emptyList()
+        var extraApks: List<String> = emptyList()
 )
 
 // No way to share array both for runtime and annotation without reflection.

--- a/composer/src/main/kotlin/com/gojuno/composer/Args.kt
+++ b/composer/src/main/kotlin/com/gojuno/composer/Args.kt
@@ -114,7 +114,16 @@ data class Args(
                 description = "Either `true` or `false` to enable/disable running tests via Android Test Orchestrator. False by default.",
                 order = 12
         )
-        var runWithOrchestrator: Boolean = false
+        var runWithOrchestrator: Boolean = false,
+
+        @Parameter(
+            names = arrayOf("--orchestrator-apks"),
+            required = false,
+            variableArity = true,
+            description = "APKs for orchestrator ( orchestrator and test-services )",
+            order = 13
+        )
+        var orchestratorApks: List<String> = emptyList()
 )
 
 // No way to share array both for runtime and annotation without reflection.

--- a/composer/src/main/kotlin/com/gojuno/composer/Main.kt
+++ b/composer/src/main/kotlin/com/gojuno/composer/Main.kt
@@ -112,8 +112,8 @@ private fun runAllTests(args: Args, testPackage: TestPackage.Valid, testRunner: 
                     val installAppApk = device.installApk(pathToApk = args.appApkPath, timeout = installTimeout)
                     val installTestApk = device.installApk(pathToApk = args.testApkPath, timeout = installTimeout)
                     val installApks: MutableCollection<Observable<Unit>> = mutableListOf(installAppApk, installTestApk)
-                    if (args.runWithOrchestrator && args.orchestratorApks.isNotEmpty()) {
-                      installApks.addAll(args.orchestratorApks.map {
+                    if (args.extraApks.isNotEmpty()) {
+                      installApks.addAll(args.extraApks.map {
                         device.installApk(pathToApk = it, timeout = installTimeout)
                       })
                     }

--- a/composer/src/main/kotlin/com/gojuno/composer/Main.kt
+++ b/composer/src/main/kotlin/com/gojuno/composer/Main.kt
@@ -111,12 +111,10 @@ private fun runAllTests(args: Args, testPackage: TestPackage.Valid, testRunner: 
                     val installTimeout = Pair(args.installTimeoutSeconds, TimeUnit.SECONDS)
                     val installAppApk = device.installApk(pathToApk = args.appApkPath, timeout = installTimeout)
                     val installTestApk = device.installApk(pathToApk = args.testApkPath, timeout = installTimeout)
-                    val installApks: MutableCollection<Observable<Unit>> = mutableListOf(installAppApk, installTestApk)
-                    if (args.extraApks.isNotEmpty()) {
-                      installApks.addAll(args.extraApks.map {
-                        device.installApk(pathToApk = it, timeout = installTimeout)
-                      })
-                    }
+                    val installApks = mutableListOf(installAppApk, installTestApk)
+                    installApks.addAll(args.extraApks.map {
+                      device.installApk(pathToApk = it, timeout = installTimeout)
+                    })
 
                     Observable
                             .concat(installApks)

--- a/composer/src/test/kotlin/com/gojuno/composer/ArgsSpec.kt
+++ b/composer/src/test/kotlin/com/gojuno/composer/ArgsSpec.kt
@@ -31,7 +31,8 @@ class ArgsSpec : Spek({
                     devicePattern = "",
                     installTimeoutSeconds = 120,
                     failIfNoTests = true,
-                    runWithOrchestrator = false
+                    runWithOrchestrator = false,
+                    extraApks = emptyList()
             ))
         }
     }
@@ -205,4 +206,16 @@ class ArgsSpec : Spek({
             assertThat(args.runWithOrchestrator).isEqualTo(true)
         }
     }
+
+  context("parse args with passed --extra-apks") {
+
+    val args by memoized {
+      parseArgs(rawArgsWithOnlyRequiredFields + arrayOf("--extra-apks", "apk1.apk", "apk2.apk"))
+    }
+
+    it("parses correctly two extra apks") {
+      assertThat(args.extraApks).isEqualTo(listOf("apk1.apk", "apk2.apk"))
+    }
+  }
+
 })


### PR DESCRIPTION
Now that we allow to use Orchestrator it would be nice to install the APKs required by Orchestrator to run.
Instead of being specific for Orchestrator this PR allows devs to install any extra APK they need.

~~There are no tests or documentation written yet because I want to validate the approach taken first, if it's ok I'll update the docs and add some tests ( suggestions on which ones are welcomed )~~