### PR TITLE
Fix js issue when displaying stacktraces in report

### DIFF
--- a/html-report/src/components/TestItem.js
+++ b/html-report/src/components/TestItem.js
@@ -66,7 +66,7 @@ export default class TestItem extends Component {
             </ul>
           </div>}
 
-          { !!data.stacktrace.length && <div className="card">
+          { !!data.stacktrace && <div className="card">
             <div className="title-common">Stacktrace</div>
             <pre className="row" style={ { overflow: 'auto' } }>{ data.stacktrace }</pre>
           </div>}


### PR DESCRIPTION
Hi everyone,

everything is in the title : the JS in `TestItem.js` is broken. The following error occurs in the JS console when opening a "test details" page:

```
Uncaught TypeError: Cannot read property 'length' of undefined
    at t.value (app.min.js:25)
    at app.min.js:97
    at s (app.min.js:97)
    at h._renderValidatedComponentWithoutOwnerOrContext (app.min.js:97)
    at h._renderValidatedComponent (app.min.js:97)
    at h.performInitialMount (app.min.js:97)
    at h.mountComponent (app.min.js:97)
    at Object.mountComponent (app.min.js:6)
    at g.mountChildren (app.min.js:97)
    at g._createInitialChildren (app.min.js:97)
```

Concretely, this error was preventing the "title" and the "screenshot" section to be displayed to the user.

The bug was introduced by this commit : https://github.com/gojuno/composer/commit/b0c12ea6e2b72c8e5a52ecbcaac72601477de119