### PR TITLE
Add support for AndroidX Test Orchestrator

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ Composer shipped as jar, to run it you need JVM 1.8+: `java -jar composer-latest
   * `False` may be applicable when you run tests conditionally(via annotation/package filters) and empty suite is a valid outcome.
   * Example: `--fail-if-no-tests false`
 * `--with-orchestrator`
-  * Either `true` or `false` to enable/disable running tests via Android Test Orchestrator.
+  * Either `true` or `false` to enable/disable running tests via AndroidX Test Orchestrator.
   * Default: `false`.
   * When enabled - minimizes shared state and isolates test crashes.
   * Requires test orchestrator & test services APKs to be installed on device before executing.

--- a/composer/src/main/kotlin/com/gojuno/composer/Args.kt
+++ b/composer/src/main/kotlin/com/gojuno/composer/Args.kt
@@ -111,7 +111,8 @@ data class Args(
         @Parameter(
                 names = arrayOf("--with-orchestrator"),
                 required = false,
-                description = "Either `true` or `false` to enable/disable running tests via Android Test Orchestrator. False by default.",
+                arity = 1,
+                description = "Either `true` or `false` to enable/disable running tests via AndroidX Test Orchestrator. False by default.",
                 order = 12
         )
         var runWithOrchestrator: Boolean = false,

--- a/composer/src/main/kotlin/com/gojuno/composer/Main.kt
+++ b/composer/src/main/kotlin/com/gojuno/composer/Main.kt
@@ -128,8 +128,8 @@ private fun runAllTests(args: Args, testPackage: TestPackage.Valid, testRunner: 
 
                                 if (args.runWithOrchestrator) {
                                     targetInstrumentation = listOf("targetInstrumentation" to "${testPackage.value}/${testRunner.value}")
-                                    testPackageName = "android.support.test.orchestrator"
-                                    testRunnerClass = "android.support.test.orchestrator.AndroidTestOrchestrator"
+                                    testPackageName = "androidx.test.orchestrator"
+                                    testRunnerClass = "androidx.test.orchestrator.AndroidTestOrchestrator"
                                 } else {
                                     targetInstrumentation = emptyList()
                                     testPackageName = testPackage.value

--- a/composer/src/main/kotlin/com/gojuno/composer/TestRun.kt
+++ b/composer/src/main/kotlin/com/gojuno/composer/TestRun.kt
@@ -52,7 +52,7 @@ fun AdbDevice.runTests(
     val logsDir = File(File(outputDir, "logs"), adbDevice.id)
     val instrumentationOutputFile = File(logsDir, "instrumentation.output")
     val commandPrefix = if (useTestServices) {
-        "CLASSPATH=$(pm path android.support.test.services) app_process / android.support.test.services.shellexecutor.ShellMain "
+        "CLASSPATH=$(pm path androidx.test.services) app_process / androidx.test.services.shellexecutor.ShellMain "
     } else ""
 
     val runTests = process(

--- a/composer/src/test/kotlin/com/gojuno/composer/ArgsSpec.kt
+++ b/composer/src/test/kotlin/com/gojuno/composer/ArgsSpec.kt
@@ -199,7 +199,7 @@ class ArgsSpec : Spek({
     context("parse args with --with-orchestrator") {
 
         val args by memoized {
-            parseArgs(rawArgsWithOnlyRequiredFields + "--with-orchestrator")
+            parseArgs(rawArgsWithOnlyRequiredFields + arrayOf("--with-orchestrator", "true"))
         }
 
         it("parses --with-orchestrator correctly") {


### PR DESCRIPTION
Fixes https://github.com/gojuno/composer/issues/166

Another approach would be to keep `--with-orchestrator` but release composer supporting androidx only. 