### PR TITLE
Read external storage variable for downloading screenshots 

### DIFF
--- a/composer/src/main/kotlin/com/gojuno/composer/TestRun.kt
+++ b/composer/src/main/kotlin/com/gojuno/composer/TestRun.kt
@@ -165,12 +165,15 @@ private fun pullTestFiles(adbDevice: AdbDevice, test: InstrumentationTest, outpu
         }
         .flatMap { screenshotsFolderOnHostMachine ->
             adbDevice
-                    .pullFolder(
+                    .externalStorage()
+                    .flatMap { externalStorageFolder ->
+                        adbDevice.pullFolder(
                             // TODO: Add support for internal storage and external storage strategies.
-                            folderOnDevice = "/storage/emulated/0/app_spoon-screenshots/${test.className}/${test.testName}",
+                            folderOnDevice = "$externalStorageFolder/app_spoon-screenshots/${test.className}/${test.testName}",
                             folderOnHostMachine = screenshotsFolderOnHostMachine,
                             logErrors = verboseOutput
-                    )
+                        )
+                    }
                     .map { File(screenshotsFolderOnHostMachine, test.testName) }
         }
         .map { screenshotsFolderOnHostMachine ->

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -3,7 +3,7 @@ ext.versions = [
 
         rxJava           : '1.3.0',
         jCommander       : '1.71',
-        commander        : '0.1.7',
+        commander        : '0.1.9',
         apacheCommonsIo  : '2.5',
         apacheCommonsLang: '3.5',
         gson             : '2.8.0',


### PR DESCRIPTION
Fixes https://github.com/gojuno/composer/issues/151

I've checked locally that screenshots are downloaded on both emulator 21 and 28.

NOTE: emulators 21-22 doesn't have writable sdcard mounted by default. So it has to be created first. For the reference https://github.com/square/spoon/issues/283